### PR TITLE
Added support for spawning lightning bolts

### DIFF
--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -237,8 +237,7 @@ public final class GlowWorld implements World {
                 int z = (chunk.getZ() << 4) + (int)(random.nextDouble() * 16);
                 int y = getHighestBlockYAt(x, z);
                 
-                // TODO: lightning.
-                strikeLightning(new Location(this, x, z, y));
+                strikeLightning(new Location(this, x, y, z));
             }
         }
         

--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -9,6 +9,7 @@ import java.util.Random;
 import java.util.logging.Level;
 
 import org.bukkit.BlockChangeDelegate;
+import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.ChunkSnapshot;
 import org.bukkit.Effect;
@@ -36,6 +37,7 @@ import net.glowstone.block.GlowBlock;
 import net.glowstone.io.ChunkIoService;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.EntityManager;
+import net.glowstone.entity.GlowLightningStrike;
 import net.glowstone.entity.GlowLivingEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.msg.LoadChunkMessage;
@@ -236,7 +238,7 @@ public final class GlowWorld implements World {
                 int y = getHighestBlockYAt(x, z);
                 
                 // TODO: lightning.
-                // strikeLightning(new Location(this, x, z, y));
+                strikeLightning(new Location(this, x, z, y));
             }
         }
         
@@ -594,11 +596,15 @@ public final class GlowWorld implements World {
     }
 
     public LightningStrike strikeLightning(Location loc) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        LightningStrike strike = new GlowLightningStrike((GlowServer) Bukkit.getServer(), this, false);
+	strike.teleport(loc);
+        return strike;
     }
 
     public LightningStrike strikeLightningEffect(Location loc) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        LightningStrike strike = new GlowLightningStrike((GlowServer) Bukkit.getServer(), this, true);
+	strike.teleport(loc);
+        return strike;
     }
 
     // Time related methods

--- a/src/main/java/net/glowstone/entity/GlowLightningStrike.java
+++ b/src/main/java/net/glowstone/entity/GlowLightningStrike.java
@@ -1,0 +1,52 @@
+package net.glowstone.entity;
+
+import net.glowstone.GlowServer;
+
+import org.bukkit.entity.LightningStrike;
+
+import net.glowstone.util.Position;
+import net.glowstone.msg.Message;
+import net.glowstone.msg.SpawnLightningStrikeMessage;
+import net.glowstone.GlowWorld;
+
+/**
+ * A GlowLightning strike is an entity produced during thunderstorms.
+ * @author Zhuowei
+ */
+public class GlowLightningStrike extends GlowEntity implements LightningStrike {
+
+    /** Whether the lightning strike is just for effect. */
+    private boolean effect;
+
+    private int ticksToLive;
+
+    public GlowLightningStrike(GlowServer server, GlowWorld world, boolean effect) {
+        super(server, world);
+        this.effect = effect;
+        this.ticksToLive = 30; //30 ticks until despawn
+    }
+    public boolean isEffect() {
+        return effect;
+    }
+
+    @Override
+    public void pulse() {
+        ticksToLive--;
+        if (ticksToLive < 0) {
+            remove();
+        }
+    }
+
+    @Override
+    public Message createSpawnMessage() {
+        int x = Position.getIntX(location);
+        int y = Position.getIntY(location);
+        int z = Position.getIntZ(location);
+        return new SpawnLightningStrikeMessage(id, x, y, z);
+    }
+
+    @Override
+    public Message createUpdateMessage() {
+        return null;
+    }
+}

--- a/src/main/java/net/glowstone/msg/SpawnLightningStrikeMessage.java
+++ b/src/main/java/net/glowstone/msg/SpawnLightningStrikeMessage.java
@@ -1,0 +1,40 @@
+package net.glowstone.msg;
+
+public final class SpawnLightningStrikeMessage extends Message {
+
+    private final int id, mode, x, y, z;
+
+    public SpawnLightningStrikeMessage(int id, int x, int y, int z) {
+        this(id, 1, x, y, z);
+    }
+
+    public SpawnLightningStrikeMessage(int id, int mode, int x, int y, int z) {
+        this.id = id;
+        this.mode = mode;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public int getMode() {
+        return mode;
+    }
+    public int getX() {
+        return x;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public int getZ() {
+        return z;
+    }
+
+
+}
+

--- a/src/main/java/net/glowstone/net/CodecLookupService.java
+++ b/src/main/java/net/glowstone/net/CodecLookupService.java
@@ -72,6 +72,7 @@ public final class CodecLookupService {
             /* 0x3C */ bind(ExplosionCodec.class);
             /* 0x3D */ bind(PlayEffectCodec.class);
             /* 0x46 */ bind(StateChangeCodec.class);
+            /* 0x46 */ bind(SpawnLightningStrikeCodec.class);
             /* 0x64 */ bind(OpenWindowCodec.class);
             /* 0x65 */ bind(CloseWindowCodec.class);
             /* 0x66 */ bind(WindowClickCodec.class);

--- a/src/main/java/net/glowstone/net/codec/SpawnLightningStrikeCodec.java
+++ b/src/main/java/net/glowstone/net/codec/SpawnLightningStrikeCodec.java
@@ -1,0 +1,38 @@
+package net.glowstone.net.codec;
+
+import java.io.IOException;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
+
+import net.glowstone.msg.SpawnLightningStrikeMessage;
+
+public final class SpawnLightningStrikeCodec extends MessageCodec<SpawnLightningStrikeMessage> {
+
+    public SpawnLightningStrikeCodec() {
+        super(SpawnLightningStrikeMessage.class, 0x47);
+    }
+
+    @Override
+    public SpawnLightningStrikeMessage decode(ChannelBuffer buffer) throws IOException {
+        int id = buffer.readInt();
+        int mode = buffer.readUnsignedByte();
+        int x = buffer.readInt();
+        int y = buffer.readInt();
+        int z = buffer.readInt();
+        return new SpawnLightningStrikeMessage(id, mode, x, y, z);
+    }
+
+    @Override
+    public ChannelBuffer encode(SpawnLightningStrikeMessage message) throws IOException {
+        ChannelBuffer buffer = ChannelBuffers.buffer(17);
+        buffer.writeInt(message.getId());
+        buffer.writeByte(message.getMode());
+        buffer.writeInt(message.getX());
+        buffer.writeInt(message.getY());
+        buffer.writeInt(message.getZ());
+        return buffer;
+    }
+
+}
+


### PR DESCRIPTION
Currently, they do not harm entities or set the ground on fire(on the server; the client generates client-side fire that is removed a few seconds later); they are spawned and removed 30 ticks later.
Also, when the spawn(location, class) method gets implemented, this might need to be updated to use it. (interestingly, CraftBukkit does not appear to use the spawn method to spawn lightning.)

It currently does not dispatch the LightningStrikeEvent.
