### PR TITLE
Changed digging to use BlockProperties, added sound effects to it

### DIFF
--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -713,6 +713,18 @@ public final class GlowWorld implements World {
             }
         }
     }
+
+    /**
+     * Plays a sound effect in the game world to everyone except for one player.
+     * @param doNotPlayTo The player which will not get the PlayEffectMessage.
+     */
+    public void playEffectExceptTo(Location location, Effect effect, int data, int radius, Player doNotPlayTo) {
+        for (Player player : getPlayers()) {
+            if (player.getLocation().distance(location) <= radius && player != doNotPlayTo) {
+                player.playEffect(location, effect, data);
+            }
+        }
+    }
     
     // misc
 

--- a/src/main/java/net/glowstone/msg/handler/DiggingMessageHandler.java
+++ b/src/main/java/net/glowstone/msg/handler/DiggingMessageHandler.java
@@ -1,5 +1,6 @@
 package net.glowstone.msg.handler;
 
+import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -8,6 +9,7 @@ import org.bukkit.inventory.ItemStack;
 
 import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
+import net.glowstone.block.BlockProperties;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.msg.DiggingMessage;
 import net.glowstone.net.Session;
@@ -48,7 +50,12 @@ public final class DiggingMessageHandler extends MessageHandler<DiggingMessage> 
 
         if (blockBroken) {
             if (block.getType() != Material.AIR) {
-                player.getInventory().addItem(new ItemStack(block.getType(), 1));
+                ItemStack[] drops = BlockProperties.get(block.getType()).getDrops();
+                for (ItemStack drop: drops) {
+                    player.getInventory().addItem(drop);
+                }
+                //Play the dig sound effect
+                world.playEffectExceptTo(block.getLocation(), Effect.STEP_SOUND, block.getTypeId(), 64, player);
             }
             block.setType(Material.AIR);
         }


### PR DESCRIPTION
Digging now looks up the drop in BlockProperties. Also, the sound effects depend on pull request #16.
Also, GlowWorld now has a playEffectExceptTo method so that we could broadcast sounds to other players without playing them to the player that made the sound.
