### PR TITLE
Version number now OVER 9000!

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -548,7 +548,7 @@ public final class GlowServer implements Server {
      * @return version of this server implementation
      */
     public String getVersion() {
-        return getClass().getPackage().getImplementationVersion();
+        return "9001." + getClass().getPackage().getImplementationVersion();
     }
     
     /**


### PR DESCRIPTION
This should "fix" issue #26.
@winsock, I hope you are happy.
The version number reported by the new and more powerful Glowstone: 
`This server is running Glowstone version 9001.git-Glowstone-0.0.0-133-g44093b6`
