### PR TITLE
fixes #48 ArrayIndexOutOfBoundsException

### DIFF
--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -401,7 +401,7 @@ public final class GlowWorld implements World {
     }
 
     public int getMaxHeight() {
-        return GlowChunk.DEPTH;
+        return GlowChunk.HEIGHT;
     }
 
     public int getSeaLevel() {


### PR DESCRIPTION
A recent commit started using world.getMaxHeight()
getMaxHeight() was returning DEPTH instead of HEIGHT.
