### PR TITLE
Entity spawn code and basic chicken class

### DIFF
--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -42,7 +42,7 @@ import net.glowstone.msg.TimeMessage;
  * @author Graham Edgecombe
  */
 public final class GlowWorld implements World {
-    
+	
     /**
      * The server of this world.
      */
@@ -148,6 +148,11 @@ public final class GlowWorld implements World {
      */
     private boolean autosave = true;
 
+    /**
+     * Arguments used to spawn entities
+     */
+    private final Object[] entitySpawnArguments;
+    
     /*
      * The world metadata service used
      */
@@ -170,6 +175,7 @@ public final class GlowWorld implements World {
         this.server = server;
         this.name = name;
         this.environment = environment;
+        entitySpawnArguments = new Object[] {this.server, this};
         provider.setWorld(this);
         chunks = new ChunkManager(this, provider.getChunkIoService(), generator);
         storageProvider = provider;
@@ -645,8 +651,21 @@ public final class GlowWorld implements World {
 
     // entity spawning
 
+    @SuppressWarnings("unchecked")
     public <T extends Entity> T spawn(Location location, Class<T> clazz) throws IllegalArgumentException {
-        throw new UnsupportedOperationException("Not supported yet.");
+        if (location == null) {
+            throw new IllegalArgumentException("Location may not be null when spawning an entity");
+        } else if (clazz == null) {
+            throw new IllegalArgumentException("Entity type class may not be null when spawning an entity");
+        } else {
+            GlowEntity glowEntity = GlowEntity.createEntity(clazz, this);
+            if (glowEntity == null) {
+                throw new IllegalArgumentException("Unable to create entity of type " + clazz.getName());
+            }
+            glowEntity.setRawLocation(location);
+            entities.add(glowEntity);
+            return (T)glowEntity;
+        }
     }
 
     public Item dropItem(Location location, ItemStack item) {
@@ -946,5 +965,12 @@ public final class GlowWorld implements World {
      */
     public File getWorldFolder() {
         return storageProvider.getFolder();
+    }
+    
+    /** Get the arguments needed for entity spawn
+     * @return spawn arguments
+     */
+    public Object[] getEntitySpawnArguments() {
+        return entitySpawnArguments;
     }
 }

--- a/src/main/java/net/glowstone/entity/EntityManager.java
+++ b/src/main/java/net/glowstone/entity/EntityManager.java
@@ -89,6 +89,10 @@ public final class EntityManager implements Iterable<GlowEntity> {
 
         throw new IllegalStateException("No free entity ids");
     }
+    
+    public int add(GlowEntity entity) {
+        return allocate(entity);
+    }
 
     /**
      * Deallocates the id for an entity.

--- a/src/main/java/net/glowstone/entity/GlowAnimal.java
+++ b/src/main/java/net/glowstone/entity/GlowAnimal.java
@@ -1,0 +1,19 @@
+package net.glowstone.entity;
+
+import net.glowstone.GlowServer;
+import net.glowstone.GlowWorld;
+
+import org.bukkit.entity.Animals;
+
+public class GlowAnimal extends GlowCreature implements Animals {
+
+    /**
+     * Creates a new animal.
+     * @param world The world this monster is in.
+     * @param type The type of monster.
+     */
+    public GlowAnimal(GlowServer server, GlowWorld world, int type) {
+        super(server, world, type);
+    }
+
+}

--- a/src/main/java/net/glowstone/entity/GlowChicken.java
+++ b/src/main/java/net/glowstone/entity/GlowChicken.java
@@ -1,0 +1,28 @@
+package net.glowstone.entity;
+
+import net.glowstone.GlowServer;
+import net.glowstone.GlowWorld;
+
+import org.bukkit.entity.Chicken;
+
+public class GlowChicken extends GlowAnimal implements Chicken {
+
+    private static final int type = 93;
+
+    /**
+     * Creates a new animal.
+     * @param world The world this monster is in.
+     */
+    public GlowChicken(GlowServer server, GlowWorld world) {
+        super(server, world, type);
+    }
+
+    /**
+     * Gets the type of creature.
+     * @return The type of creature.
+     */
+    public int getType() {
+        return type;
+    }
+
+}

--- a/src/main/java/net/glowstone/entity/GlowCreature.java
+++ b/src/main/java/net/glowstone/entity/GlowCreature.java
@@ -1,7 +1,7 @@
 package net.glowstone.entity;
 
 import net.glowstone.GlowServer;
-      
+
 import org.bukkit.entity.Creature;
 
 import net.glowstone.util.Position;
@@ -12,25 +12,25 @@ import net.glowstone.GlowWorld;
 import org.bukkit.entity.LivingEntity;
 
 /**
- * Represents a monster such as a creeper.
+ * Represents a creature such as a creeper.
  * @author Graham Edgecombe
  */
-public final class GlowCreature extends GlowLivingEntity implements Creature {
+public class GlowCreature extends GlowLivingEntity implements Creature {
 
     /**
-     * The type of monster.
+     * The type of creature.
      */
     private final int type;
-   
+
     /**
-     * The monster's target.
+     * The creature target.
      */
     private LivingEntity target;
 
     /**
-     * Creates a new monster.
-     * @param world The world this monster is in.
-     * @param type The type of monster.
+     * Creates a new creature.
+     * @param world The world this creature is in.
+     * @param type The type of creature.
      */
     public GlowCreature(GlowServer server, GlowWorld world, int type) {
         super(server, world);
@@ -38,8 +38,8 @@ public final class GlowCreature extends GlowLivingEntity implements Creature {
     }
 
     /**
-     * Gets the type of monster.
-     * @return The type of monster.
+     * Gets the type of creature.
+     * @return The type of creature.
      */
     public int getType() {
         return type;
@@ -66,4 +66,5 @@ public final class GlowCreature extends GlowLivingEntity implements Creature {
     public int getMaxHealth() {
         throw new UnsupportedOperationException("Not supported yet!");
     }
+
 }

--- a/src/main/java/net/glowstone/util/reflection/ReflectHelper.java
+++ b/src/main/java/net/glowstone/util/reflection/ReflectHelper.java
@@ -1,0 +1,80 @@
+package net.glowstone.util.reflection;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+public class ReflectHelper {
+
+    /**
+     * Constructs an object of a give class
+     * @param clazz the class type to construct
+     * @param argTypes the types of constructor arguments
+     * @param args the arguments to pass to the method
+     * @return a constructed object of the class or null on failure
+     */
+
+    public static <T> T construct(Class<T> clazz, Class<?>[] argTypes, Object[] args) {
+
+        Constructor<?>[] constructors;
+        try {
+            constructors = clazz.getConstructors();
+        } catch (SecurityException se) {
+            System.out.println("Security exception");
+            return null;
+        }
+
+        for (Constructor<?> c : constructors) {
+
+            Class<?>[] params = c.getParameterTypes();
+
+            if (checkArgMatch(argTypes, params)) {
+                try {
+                    @SuppressWarnings("unchecked")
+                    T newObject = (T)c.newInstance(args);
+                    return newObject;
+                } catch (IllegalAccessException iae) {
+                    continue;
+                } catch (IllegalArgumentException iae) {
+                    continue;
+                } catch (InstantiationException ie) {
+                    continue;
+                } catch (InvocationTargetException ie) {
+                    continue;
+                } catch (ExceptionInInitializerError eiie) {
+                    continue;
+                }
+            }
+        }
+        System.out.println("No const match");
+        return null;
+    }
+
+    /**
+     * Helper method to check if argument arrays match
+     * @param a1 the first argument array
+     * @param a2 the second argument array
+     * @return true if the arrays match
+     */
+
+    private static boolean checkArgMatch(Class<?>[] a1, Class<?>[] a2) {
+
+        if (a1 == null || a2 == null) {
+            return false;
+        }
+
+        if (a1.length != a2.length) {
+            return false;
+        }
+
+        int size = a1.length;
+        for (int i = 0; i < size; i++) {
+            if (!a1[i].equals(a2[i])) {
+                return false;
+            }
+        }
+
+        return true;
+
+    }
+
+}


### PR DESCRIPTION
This pull adds code to allow entities to be spawned in the world.

It also adds a GlowChicken class as an example.

A map is created which maps Bukkit entity classes to GlowStone entity classes and then reflection is used to construct the entity.

There is also a ReflectHelper class that could be expanded if other reflection operations are required.
