### PR TITLE
Remove org.bouncycastle libraries to reduce filesize significantly.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ repositories {
 // Dependencies used by our project
 dependencies {
     compile group: 'org.bukkit', name: 'bukkit', version: ext.bukkitVersion
-    compile 'com.flowpowered:flow-networking:0.1.0-SNAPSHOT'
+    compile 'com.flowpowered:flow-networking:0.1.1-SNAPSHOT'
     compile 'jline:jline:2.11'
     //compile 'mysql:mysql-connector-java:5.1.14'
     //compile 'org.xerial:sqlite-jdbc:3.7.2'

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,7 @@ repositories {
 // Dependencies used by our project
 dependencies {
     compile group: 'org.bukkit', name: 'bukkit', version: ext.bukkitVersion
-    compile 'com.flowpowered:flow-networking:0.1.1-SNAPSHOT'
+    compile 'com.flowpowered:flow-networking:0.1.0-SNAPSHOT'
     compile 'jline:jline:2.11'
     //compile 'mysql:mysql-connector-java:5.1.14'
     //compile 'org.xerial:sqlite-jdbc:3.7.2'

--- a/build.gradle
+++ b/build.gradle
@@ -89,8 +89,7 @@ repositories {
 // Dependencies used by our project
 dependencies {
     compile group: 'org.bukkit', name: 'bukkit', version: ext.bukkitVersion
-    compile 'com.flowpowered:flow-networking:0.1.0-SNAPSHOT'
-    compile 'org.bouncycastle:bcprov-jdk16:1.46'
+    compile 'com.flowpowered:flow-networking:0.1.1-SNAPSHOT'
     compile 'jline:jline:2.11'
     //compile 'mysql:mysql-connector-java:5.1.14'
     //compile 'org.xerial:sqlite-jdbc:3.7.2'

--- a/src/main/java/net/glowstone/util/SecurityUtils.java
+++ b/src/main/java/net/glowstone/util/SecurityUtils.java
@@ -1,11 +1,15 @@
 package net.glowstone.util;
 
-import net.glowstone.GlowServer;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-
-import java.security.*;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.logging.Level;
+
+import net.glowstone.GlowServer;
 
 /**
  * Utility class for performing encrypted authentication
@@ -13,10 +17,6 @@ import java.util.logging.Level;
 public class SecurityUtils {
 
     private static SecureRandom random = new SecureRandom();
-
-    static {
-        Security.addProvider(new BouncyCastleProvider());
-    }
 
     private SecurityUtils() {
     }


### PR DESCRIPTION
They are unnecessary, as the javax libraries are faster and included in JDK implementations.
