### PR TITLE
Change Item registry's hash map size from 16 to 512.

### DIFF
--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -29,7 +29,7 @@ public final class ItemTable {
     ////////////////////////////////////////////////////////////////////////////
     // Data
 
-    private final Map<Integer, ItemType> idToType = new HashMap<>();
+    private final Map<Integer, ItemType> idToType = new HashMap<>(512);
 
     private int nextBlockId, nextItemId;
 


### PR DESCRIPTION
This should increase speed when all of the items are added from Quadratic time to
Linear time.
