### PR TITLE
Support BungeeCord player data on connect

### DIFF
--- a/src/main/java/net/glowstone/net/handler/handshake/HandshakeHandler.java
+++ b/src/main/java/net/glowstone/net/handler/handshake/HandshakeHandler.java
@@ -1,12 +1,25 @@
 package net.glowstone.net.handler.handshake;
 
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Level;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
 import com.flowpowered.networking.MessageHandler;
 import net.glowstone.GlowServer;
+import net.glowstone.entity.meta.PlayerProperty;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.handshake.HandshakeMessage;
 import net.glowstone.net.protocol.GlowProtocol;
 import net.glowstone.net.protocol.LoginProtocol;
 import net.glowstone.net.protocol.StatusProtocol;
+import net.glowstone.util.UuidUtils;
 
 public class HandshakeHandler implements MessageHandler<GlowSession, HandshakeMessage> {
 
@@ -29,6 +42,44 @@ public class HandshakeHandler implements MessageHandler<GlowSession, HandshakeMe
         } else {
             session.disconnect("Invalid state");
             return;
+        }
+        
+        //BungeeCord modifies the hostname in the HandshakeMessage to contain the clients UUID and (optionally) properties
+        String[] parts = message.getAddress().split("\00");
+        if (parts.length == 3 || parts.length == 4) {
+            if (parts.length == 4) {
+                try {
+                    //Spoof properties
+                    JSONArray jsonProperties = (JSONArray) new JSONParser().parse(parts[3]);
+
+                    final List<PlayerProperty> properties = new ArrayList<>(jsonProperties.size());
+                    for (Object obj : jsonProperties) {
+                        JSONObject propJson = (JSONObject) obj;
+                        String propName = (String) propJson.get("name");
+                        String value = (String) propJson.get("value");
+                        String signature = (String) propJson.get("signature");
+                        properties.add(new PlayerProperty(propName, value, signature));
+                    }
+                    session.setSpoofedProperties(properties);
+                } catch (ParseException | ClassCastException e) {
+                    GlowServer.logger.log(Level.SEVERE, "Failed parsing client properties: {0}", e);
+                    session.disconnect("Failed reading properties.");
+                    return;
+                }
+            }
+            
+            // TODO There is currently no use for the hostname the client connected to
+            //      because Glowstone uses a deprecated constructor to instantiate the PlayerLoginEvent.
+            //      Once the hostname is used, this value should replace it if the user connects through BungeeCord
+            //String spoofedHostname = parts[0];
+            
+            //Spoof client address
+            InetSocketAddress spoofedAddress = new InetSocketAddress(parts[1], session.getAddress().getPort());
+            session.setAddress(spoofedAddress);
+            
+            //Spoof UUID
+            UUID spoofedUuid = UuidUtils.fromFlatString(parts[2]);
+            session.setSpoofedUUID(spoofedUuid);
         }
 
         //GlowServer.logger.info("Handshake [" + message.getAddress() + ":" + message.getPort() + "], next state " + newProtocol);

--- a/src/main/java/net/glowstone/net/handler/login/LoginStartHandler.java
+++ b/src/main/java/net/glowstone/net/handler/login/LoginStartHandler.java
@@ -29,8 +29,16 @@ public final class LoginStartHandler implements MessageHandler<GlowSession, Logi
             //Send created request message and wait for the response
             session.send(new EncryptionKeyRequestMessage(sessionId, publicKey, verifyToken));
         } else {
-            UUID uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8));
-            session.setPlayer(new PlayerProfile(name, uuid));
+            UUID uuid = session.getSpoofedUUID();
+            if (uuid == null) {
+                uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8));
+            }
+            
+            if (session.getSpoofedProperties() == null) {
+                session.setPlayer(new PlayerProfile(name, uuid));
+            } else {
+                session.setPlayer(new PlayerProfile(name, uuid, session.getSpoofedProperties()));
+            }
         }
     }
 }


### PR DESCRIPTION
Adds support for BungeeCord player data, in particular player IP, which is otherwise hidden by the proxy, and the player properties, which cannot be retrieved from the auth server because the server has to run in offline mode.
It is not yet possible to get the hostname with which the client connected to the server in Glowstone, therefore the hostname which is also transmitted by the BungeeCord is dropped in the process. The code required to get the hostname is included in this PR, it's just commented to not raise warnings about being unused.
