### PR TITLE
Allow placement of blocks overriding tallgrass and fire.

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -117,8 +117,8 @@ public class BlockType extends ItemType {
         GlowBlock target = against.getRelative(face);
         GlowBlockState newState = target.getState();
 
-        // only allow placement inside tall-grass, air, or liquid
-        if (against.getType() == Material.LONG_GRASS) {
+        // only allow placement inside tall-grass, air, liquid or fire
+        if (against.getType() == Material.LONG_GRASS || against.getType() == Material.FIRE) {
             target = against;
         } else if (!target.isEmpty() && !target.isLiquid()) {
             //revert(player, target);
@@ -145,7 +145,7 @@ public class BlockType extends ItemType {
         newState.update(true);
 
         // play a sound effect
-        // todo: vary sound effect based on block type
+        // TODO: vary sound effect based on block type
         target.getWorld().playSound(target.getLocation(), Sound.DIG_WOOD, 1, 1);
 
         // do any after-place actions

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -117,10 +117,8 @@ public class BlockType extends ItemType {
         GlowBlock target = against.getRelative(face);
         GlowBlockState newState = target.getState();
 
-        // only allow placement inside tall-grass, air, liquid or fire
-        if (against.getType() == Material.LONG_GRASS || against.getType() == Material.FIRE) {
-            target = against;
-        } else if (!target.isEmpty() && !target.isLiquid()) {
+        // only allow placement inside tall-grass, air, liquids or fire
+        if (!target.isEmpty() && !target.isLiquid() && !(target.getType() == Material.FIRE || target.getType() == Material.LONG_GRASS)) {
             //revert(player, target);
             return;
         }


### PR DESCRIPTION
Currently, players are unable to place inside the fire block, as you can in vanilla. This PR adds this ability.

Also, when a block is attempted to be replacing a tallgrass block, it creates the block on what the block was placed against.
