### PR TITLE
Added: Dispensers

### DIFF
--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -44,6 +44,7 @@ public final class ItemTable {
         reg(Material.WORKBENCH, new BlockWorkbench());
         reg(Material.ENDER_CHEST, new BlockEnderchest());
         reg(Material.CHEST, new BlockChest());
+        reg(Material.DISPENSER, new BlockDispenser());
         reg(Material.BOOKSHELF, new BlockDirectDrops(Material.BOOK, 3));
         reg(Material.CLAY, new BlockDirectDrops(Material.CLAY_BALL, 4));
         reg(Material.DOUBLE_STEP, new BlockDoubleSlab());

--- a/src/main/java/net/glowstone/block/blocktype/BlockContainer.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockContainer.java
@@ -4,6 +4,7 @@ import net.glowstone.block.GlowBlock;
 import net.glowstone.block.entity.TEContainer;
 import net.glowstone.block.entity.TileEntity;
 import net.glowstone.entity.GlowPlayer;
+import org.bukkit.Location;
 import org.bukkit.block.BlockFace;
 import org.bukkit.util.Vector;
 
@@ -21,6 +22,43 @@ public class BlockContainer extends BlockType {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Gets the BlockFace opposite of the direction the location is facing. Usually used to set the way container blocks
+     * face when being placed.
+     *
+     * @param location Location to get opposite of
+     * @param inverted If up/down should be used
+     * @return Opposite BlockFace or EAST if pitch is invalid
+     */
+    public BlockFace getOppositeBlockFace(Location location, boolean inverted) {
+        double rot = location.getYaw() % 360;
+        if (inverted) {
+            // TODO: Check the 67.5 pitch in source. This is based off of WorldEdit's number for this.
+            double pitch = location.getPitch() % 90;
+            if (pitch < -67.5D) {
+                return BlockFace.DOWN;
+            } else if (pitch > 67.5D) {
+                return BlockFace.UP;
+            }
+        }
+        if (rot < 0) {
+            rot += 360.0;
+        }
+        if (0 <= rot && rot < 45) {
+            return BlockFace.NORTH;
+        } else if (45 <= rot && rot < 135) {
+            return BlockFace.EAST;
+        } else if (135 <= rot && rot < 225) {
+            return BlockFace.SOUTH;
+        } else if (225 <= rot && rot < 315) {
+            return BlockFace.WEST;
+        } else if (315 <= rot && rot < 360.0) {
+            return BlockFace.NORTH;
+        } else {
+            return BlockFace.EAST;
+        }
     }
 
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockDispenser.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockDispenser.java
@@ -1,0 +1,39 @@
+package net.glowstone.block.blocktype;
+
+import net.glowstone.GlowChunk;
+import net.glowstone.GlowServer;
+import net.glowstone.block.GlowBlockState;
+import net.glowstone.block.entity.TEDispenser;
+import net.glowstone.block.entity.TileEntity;
+import net.glowstone.entity.GlowPlayer;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.material.Dispenser;
+import org.bukkit.material.MaterialData;
+import org.bukkit.util.Vector;
+
+public class BlockDispenser extends BlockContainer {
+
+    public BlockDispenser() {
+        setDrops(new ItemStack(Material.DISPENSER));
+    }
+
+    @Override
+    public TileEntity createTileEntity(GlowChunk chunk, int cx, int cy, int cz) {
+        return new TEDispenser(chunk.getBlock(cx, cy, cz));
+    }
+
+    @Override
+    public void placeBlock(GlowPlayer player, GlowBlockState state, BlockFace face, ItemStack holding, Vector clickedLoc) {
+        super.placeBlock(player, state, face, holding, clickedLoc);
+        final MaterialData data = state.getData();
+        if (data instanceof Dispenser) {
+            ((Dispenser) data).setFacingDirection(getOppositeBlockFace(player.getLocation(), true));
+            state.setData(data);
+        } else {
+            GlowServer.logger.warning("Placing " + getMaterial().name() + ": MaterialData was of wrong type (" + data.getClass().getName() + ")");
+        }
+    }
+
+}

--- a/src/main/java/net/glowstone/block/entity/TEDispenser.java
+++ b/src/main/java/net/glowstone/block/entity/TEDispenser.java
@@ -1,0 +1,11 @@
+package net.glowstone.block.entity;
+
+import net.glowstone.block.GlowBlock;
+import org.bukkit.event.inventory.InventoryType;
+
+public class TEDispenser extends TEContainer {
+
+    public TEDispenser(GlowBlock block) {
+        super(block, InventoryType.DISPENSER);
+    }
+}


### PR DESCRIPTION
Partially fixes #119. This adds a handy method to BlockContainer to get the opposite BlockFace based off of a Location. This may be better-suited in another class, but it works here. The boolean in getOppositeBlockFace could be substituted with an enum. If you would rather have that, let me know.
