### PR TITLE
Internally implement 1.8 block types

### DIFF
--- a/src/main/java/net/glowstone/ChunkManager.java
+++ b/src/main/java/net/glowstone/ChunkManager.java
@@ -239,10 +239,8 @@ public final class ChunkManager {
                 // this is sort of messy.
                 if (extSections[i] != null) {
                     sections[i] = new GlowChunk.ChunkSection();
-                    // truncate shorts down to bytes
-                    // todo: when chunk structure is updated for 1.8+, include lower 0xfff
                     for (int j = 0; j < extSections[i].length; ++j) {
-                        sections[i].types[j] = (byte) extSections[i][j];
+                        sections[i].types[j] = (char) (extSections[i][j] << 4);
                     }
                 }
             }
@@ -258,7 +256,9 @@ public final class ChunkManager {
                 // this is sort of messy.
                 if (blockSections[i] != null) {
                     sections[i] = new GlowChunk.ChunkSection();
-                    System.arraycopy(blockSections[i], 0, sections[i].types, 0, sections[i].types.length);
+                    for (int j = 0; j < blockSections[i].length; ++j) {
+                        sections[i].types[j] = (char) (blockSections[i][j] << 4);
+                    }
                 }
             }
             chunk.initializeSections(sections);
@@ -276,7 +276,7 @@ public final class ChunkManager {
             for (int cx = 0; cx < 16; ++cx) {
                 for (int cz = 0; cz < 16; ++cz) {
                     for (int cy = by; cy < by + 16; ++cy) {
-                        sec.types[sec.index(cx, cy, cz)] = types[(cx * 16 + cz) * 128 + cy];
+                        sec.types[sec.index(cx, cy, cz)] = (char) (((char) types[(cx * 16 + cz) * 128 + cy]) << 4);
                     }
                 }
             }

--- a/src/main/java/net/glowstone/GlowChunk.java
+++ b/src/main/java/net/glowstone/GlowChunk.java
@@ -142,7 +142,9 @@ public final class GlowChunk implements Chunk {
         public void recount() {
             count = 0;
             for(char type : types) {
-                if (type != 0) count++;
+                if (type != 0) {
+                    count++;
+                }
             }
         }
 
@@ -436,9 +438,13 @@ public final class GlowChunk implements Chunk {
         // update the type
         int index = section.index(x, y, z);
         if (type == 0) {
-            if(section.types[index] != 0) section.count--;
+            if(section.types[index] != 0) {
+                section.count--;
+            }
         } else {
-            if(section.types[index] == 0) section.count++;
+            if(section.types[index] == 0) {
+                section.count++;
+            }
         }
         section.types[index] = (char) (type << 4);
 

--- a/src/main/java/net/glowstone/GlowChunk.java
+++ b/src/main/java/net/glowstone/GlowChunk.java
@@ -478,6 +478,7 @@ public final class GlowChunk implements Chunk {
         if (section == null) return;  // can't set metadata on an empty section
         int index = section.index(x, y, z);
         if ((section.types[index] << 4) == 0) return;  // can't set metadata on air
+        section.types[index] &= 0xfff0;
         section.types[index] |= metaData;
     }
 

--- a/src/main/java/net/glowstone/GlowChunk.java
+++ b/src/main/java/net/glowstone/GlowChunk.java
@@ -477,7 +477,7 @@ public final class GlowChunk implements Chunk {
         ChunkSection section = getSection(y);
         if (section == null) return;  // can't set metadata on an empty section
         int index = section.index(x, y, z);
-        if ((section.types[index] << 4) == 0) return;  // can't set metadata on air
+        if (section.types[index] == 0) return;  // can't set metadata on air
         section.types[index] &= 0xfff0;
         section.types[index] |= metaData;
     }

--- a/src/main/java/net/glowstone/GlowChunkSnapshot.java
+++ b/src/main/java/net/glowstone/GlowChunkSnapshot.java
@@ -110,12 +110,12 @@ public class GlowChunkSnapshot implements ChunkSnapshot {
 
     public int getBlockTypeId(int x, int y, int z) {
         ChunkSection section = getSection(y);
-        return section == null ? 0 : (section.types[section.index(x, y, z)] & 0xff);
+        return section == null ? 0 : section.types[section.index(x, y, z)] >> 4;
     }
 
     public int getBlockData(int x, int y, int z) {
         ChunkSection section = getSection(y);
-        return section == null ? 0 : section.metaData.get(section.index(x, y, z));
+        return section == null ? 0 : section.types[section.index(x, y, z)] & 0xF;
     }
 
     public int getBlockSkyLight(int x, int y, int z) {

--- a/src/main/java/net/glowstone/io/anvil/AnvilChunkIoService.java
+++ b/src/main/java/net/glowstone/io/anvil/AnvilChunkIoService.java
@@ -81,7 +81,7 @@ public final class AnvilChunkIoService implements ChunkIoService {
             NibbleArray data = new NibbleArray(sectionTag.getByteArray("Data"));
             NibbleArray blockLight = new NibbleArray(sectionTag.getByteArray("BlockLight"));
             NibbleArray skyLight = new NibbleArray(sectionTag.getByteArray("SkyLight"));
-            
+
             char[] types = new char[rawTypes.length];
             for(int i = 0; i < rawTypes.length; i++) {
                 types[i] = (char) (((extTypes == null ? 0 : extTypes.get(i)) << 12) | (rawTypes[i] << 4) | data.get(i));
@@ -170,7 +170,9 @@ public final class AnvilChunkIoService implements ChunkIoService {
                 rawTypes[j] = (byte) ((sec.types[j] >> 4) & 0xFF);
                 byte extType = (byte) (sec.types[j] >> 12);
                 if(extType > 0) {
-                    if(extTypes == null) extTypes = new NibbleArray(sec.types.length);
+                    if(extTypes == null) {
+                        extTypes = new NibbleArray(sec.types.length);
+                    }
                     extTypes.set(j, extType);
                 }
                 data.set(j, (byte) (sec.types[j] & 0xF));

--- a/src/main/java/net/glowstone/io/anvil/AnvilChunkIoService.java
+++ b/src/main/java/net/glowstone/io/anvil/AnvilChunkIoService.java
@@ -178,7 +178,9 @@ public final class AnvilChunkIoService implements ChunkIoService {
                 data.set(j, (byte) (sec.types[j] & 0xF));
             }
             sectionTag.putByteArray("Blocks", rawTypes);
-            if(extTypes != null) sectionTag.putByteArray("Add", extTypes.getRawData());
+            if(extTypes != null) {
+                sectionTag.putByteArray("Add", extTypes.getRawData());
+            }
             sectionTag.putByteArray("Data", data.getRawData());
             sectionTag.putByteArray("BlockLight", sec.blockLight.getRawData());
             sectionTag.putByteArray("SkyLight", sec.skyLight.getRawData());

--- a/src/main/java/net/glowstone/io/anvil/AnvilChunkIoService.java
+++ b/src/main/java/net/glowstone/io/anvil/AnvilChunkIoService.java
@@ -76,11 +76,17 @@ public final class AnvilChunkIoService implements ChunkIoService {
         ChunkSection[] sections = new ChunkSection[16];
         for (CompoundTag sectionTag : sectionList) {
             int y = sectionTag.getByte("Y");
-            byte[] types = sectionTag.getByteArray("Blocks");
+            byte[] rawTypes = sectionTag.getByteArray("Blocks");
+            NibbleArray extTypes = sectionTag.containsKey("Add") ? new NibbleArray(sectionTag.getByteArray("Add")) : null;
             NibbleArray data = new NibbleArray(sectionTag.getByteArray("Data"));
             NibbleArray blockLight = new NibbleArray(sectionTag.getByteArray("BlockLight"));
             NibbleArray skyLight = new NibbleArray(sectionTag.getByteArray("SkyLight"));
-            sections[y] = new ChunkSection(types, data, skyLight, blockLight);
+            
+            char[] types = new char[rawTypes.length];
+            for(int i = 0; i < rawTypes.length; i++) {
+                types[i] = (char) (((extTypes == null ? 0 : extTypes.get(i)) << 12) | (rawTypes[i] << 4) | data.get(i));
+            }
+            sections[y] = new ChunkSection(types, skyLight, blockLight);
         }
 
         // initialize the chunk
@@ -156,8 +162,22 @@ public final class AnvilChunkIoService implements ChunkIoService {
 
             CompoundTag sectionTag = new CompoundTag();
             sectionTag.putByte("Y", i);
-            sectionTag.putByteArray("Blocks", sec.types);
-            sectionTag.putByteArray("Data", sec.metaData.getRawData());
+            
+            byte[] rawTypes = new byte[sec.types.length];
+            NibbleArray extTypes = null;
+            NibbleArray data = new NibbleArray(sec.types.length);
+            for(int j = 0; j < sec.types.length; j++) {
+                rawTypes[j] = (byte) ((sec.types[j] >> 4) & 0xFF);
+                byte extType = (byte) (sec.types[j] >> 12);
+                if(extType > 0) {
+                    if(extTypes == null) extTypes = new NibbleArray(sec.types.length);
+                    extTypes.set(j, extType);
+                }
+                data.set(j, (byte) (sec.types[j] & 0xF));
+            }
+            sectionTag.putByteArray("Blocks", rawTypes);
+            if(extTypes != null) sectionTag.putByteArray("Add", extTypes.getRawData());
+            sectionTag.putByteArray("Data", data.getRawData());
             sectionTag.putByteArray("BlockLight", sec.blockLight.getRawData());
             sectionTag.putByteArray("SkyLight", sec.skyLight.getRawData());
 


### PR DESCRIPTION
In 1.8, block types were changed to unify both block types and data.

Block types are now represented as an unsigned short:

```
blockType = (char) ((extNibbleId << 12) | (blockId << 4) | blockNibbleData)
```

With this PR, we maintain compatibility with the Bukkit API and only implement this internally.
