### PR TITLE
Replace Bukkit API dependency with MIT-licensed alternative

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ mainClassName = "net.glowstone.GlowServer"
 
 // Extended project information
 ext.url = 'https://github.com/SpaceManiac/Glowstone'
-ext.bukkitVersion = '1.7.9-R0.1'
+ext.bukkitVersion = '0.0.1'
 ext.gitDescribe = getVersionName()
 
 // Minimum Java version required
@@ -88,7 +88,7 @@ repositories {
 
 // Dependencies used by our project
 dependencies {
-    compile group: 'org.bukkit', name: 'bukkit', version: project.ext.bukkitVersion
+    compile group: 'com.github.deathcap', name: 'bedrock-api', version: project.ext.bukkitVersion
     compile 'com.flowpowered:flow-networking:1.0.0-SNAPSHOT'
     compile 'jline:jline:2.11'
     //compile 'mysql:mysql-connector-java:5.1.14'

--- a/src/main/java/net/glowstone/ConsoleManager.java
+++ b/src/main/java/net/glowstone/ConsoleManager.java
@@ -125,7 +125,7 @@ public final class ConsoleManager {
     }
 
     private String colorize(String string) {
-        if (string.indexOf(ChatColor.COLOR_CHAR) < 0) {
+        if (string.indexOf(ChatColor.COLOR_CHAR.ordinal()) < 0) {
             return string;  // no colors in the message
         } else if (!jLine || !reader.getTerminal().isAnsiSupported()) {
             return ChatColor.stripColor(string);  // color not supported

--- a/src/main/java/net/glowstone/EventFactory.java
+++ b/src/main/java/net/glowstone/EventFactory.java
@@ -123,7 +123,7 @@ public final class EventFactory {
             event.disallow(PlayerLoginEvent.Result.KICK_BANNED, "Banned: " + ipBans.getBanEntry(address).getReason());
         } else if (server.hasWhitelist() && !player.isWhitelisted()) {
             event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, "You are not whitelisted on this server.");
-        } else if (server.getOnlinePlayers().length >= server.getMaxPlayers()) {
+        } else if (server.getOnlinePlayers().size() >= server.getMaxPlayers()) {
             event.disallow(PlayerLoginEvent.Result.KICK_FULL,
                     "The server is full (" + player.getServer().getMaxPlayers() + " players).");
         }

--- a/src/main/java/net/glowstone/GlowOfflinePlayer.java
+++ b/src/main/java/net/glowstone/GlowOfflinePlayer.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 /**
  * Represents a player which is not connected to the server.
  */
-@SerializableAs("Player")
+//@SerializableAs("Player") // TODO: fix cannot find value()
 public final class GlowOfflinePlayer implements OfflinePlayer {
 
     private final GlowServer server;

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -649,6 +649,11 @@ public final class GlowServer implements Server {
         return getClass().getPackage().getSpecificationVersion();
     }
 
+    @Override
+    public Player[] _INVALID_getOnlinePlayers() {
+        return getOnlinePlayers().toArray(new Player[0]);
+    }
+
     public Logger getLogger() {
         return logger;
     }
@@ -758,14 +763,14 @@ public final class GlowServer implements Server {
         return offlinePlayers;
     }
 
-    public Player[] getOnlinePlayers() {
+    public Collection<Player> getOnlinePlayers() {
         ArrayList<Player> result = new ArrayList<>();
         for (World world : getWorlds()) {
             for (Player player : world.getPlayers()) {
                 result.add(player);
             }
         }
-        return result.toArray(new Player[result.size()]);
+        return result;
     }
 
     public OfflinePlayer[] getOfflinePlayers() {

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -54,7 +54,7 @@ import java.util.logging.Level;
  * Represents an in-game player.
  * @author Graham Edgecombe
  */
-@DelegateDeserialization(GlowOfflinePlayer.class)
+//@DelegateDeserialization(GlowOfflinePlayer.class) // TODO: fix cannot find value()
 public final class GlowPlayer extends GlowHumanEntity implements Player {
 
     /**

--- a/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
+++ b/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
@@ -20,7 +20,7 @@ public final class StatusRequestHandler implements MessageHandler<GlowSession, S
     public void handle(GlowSession session, StatusRequestMessage message) {
         // create and call the event
         GlowServer server = session.getServer();
-        int online = server.getOnlinePlayers().length;
+        int online = server.getOnlinePlayers().size();
         InetAddress address = session.getAddress().getAddress();
 
         StatusEvent event = new StatusEvent(address, server.getMotd(), online, server.getMaxPlayers());

--- a/src/main/java/net/glowstone/scheduler/GlowScheduler.java
+++ b/src/main/java/net/glowstone/scheduler/GlowScheduler.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import net.glowstone.GlowServer;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.scheduler.BukkitWorker;
@@ -215,12 +216,27 @@ public final class GlowScheduler implements BukkitScheduler {
         return scheduleSyncRepeatingTask(plugin, task, delay, -1);
     }
 
+    @Override
+    public int scheduleSyncDelayedTask(Plugin plugin, BukkitRunnable bukkitRunnable, long l) {
+        return scheduleSyncDelayedTask(plugin, (Runnable) bukkitRunnable, l);
+    }
+
     public int scheduleSyncDelayedTask(Plugin plugin, Runnable task) {
         return scheduleSyncDelayedTask(plugin, task, 0);
     }
 
+    @Override
+    public int scheduleSyncDelayedTask(Plugin plugin, BukkitRunnable bukkitRunnable) {
+        return scheduleSyncDelayedTask(plugin, (Runnable) bukkitRunnable);
+    }
+
     public int scheduleSyncRepeatingTask(Plugin plugin, Runnable task, long delay, long period) {
         return schedule(new GlowTask(plugin, task, true, delay, period)).getTaskId();
+    }
+
+    @Override
+    public int scheduleSyncRepeatingTask(Plugin plugin, BukkitRunnable bukkitRunnable, long l, long l2) {
+        return scheduleSyncRepeatingTask(plugin, (Runnable) bukkitRunnable, l, l2);
     }
 
     @Deprecated
@@ -258,24 +274,54 @@ public final class GlowScheduler implements BukkitScheduler {
         return runTaskLater(plugin, task, 0);
     }
 
+    @Override
+    public BukkitTask runTask(Plugin plugin, BukkitRunnable bukkitRunnable) throws IllegalArgumentException {
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
     public BukkitTask runTaskAsynchronously(Plugin plugin, Runnable task) throws IllegalArgumentException {
         return runTaskLaterAsynchronously(plugin, task, 0);
+    }
+
+    @Override
+    public BukkitTask runTaskAsynchronously(Plugin plugin, BukkitRunnable bukkitRunnable) throws IllegalArgumentException {
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
     }
 
     public BukkitTask runTaskLater(Plugin plugin, Runnable task, long delay) throws IllegalArgumentException {
         return runTaskTimer(plugin, task, delay, -1);
     }
 
+    @Override
+    public BukkitTask runTaskLater(Plugin plugin, BukkitRunnable bukkitRunnable, long l) throws IllegalArgumentException {
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
     public BukkitTask runTaskLaterAsynchronously(Plugin plugin, Runnable task, long delay) throws IllegalArgumentException {
         return runTaskTimerAsynchronously(plugin, task, delay, -1);
+    }
+
+    @Override
+    public BukkitTask runTaskLaterAsynchronously(Plugin plugin, BukkitRunnable bukkitRunnable, long l) throws IllegalArgumentException {
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
     }
 
     public BukkitTask runTaskTimer(Plugin plugin, Runnable task, long delay, long period) throws IllegalArgumentException {
         return schedule(new GlowTask(plugin, task, true, delay, period));
     }
 
+    @Override
+    public BukkitTask runTaskTimer(Plugin plugin, BukkitRunnable bukkitRunnable, long l, long l2) throws IllegalArgumentException {
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
     public BukkitTask runTaskTimerAsynchronously(Plugin plugin, Runnable task, long delay, long period) throws IllegalArgumentException {
         return schedule(new GlowTask(plugin, task, false, delay, period));
+    }
+
+    @Override
+    public BukkitTask runTaskTimerAsynchronously(Plugin plugin, BukkitRunnable bukkitRunnable, long l, long l2) throws IllegalArgumentException {
+        return null;  //To change body of implemented methods use File | Settings | File Templates.
     }
 
     public void cancelTask(int taskId) {

--- a/src/test/java/net/glowstone/testutils/ServerShim.java
+++ b/src/test/java/net/glowstone/testutils/ServerShim.java
@@ -50,6 +50,11 @@ public class ServerShim implements Server {
         return "Test-Shim";
     }
 
+    @Override
+    public Player[] _INVALID_getOnlinePlayers() {
+        return getOnlinePlayers().toArray(new Player[0]);
+    }
+
     public ItemFactory getItemFactory() {
         return GlowItemFactory.instance();
     }
@@ -60,8 +65,8 @@ public class ServerShim implements Server {
 
     // do nothing stubs
 
-    public Player[] getOnlinePlayers() {
-        return new Player[0];
+    public Collection<Player> getOnlinePlayers() {
+        return new ArrayList<Player>();
     }
 
     public int getMaxPlayers() {


### PR DESCRIPTION
(Not ready to pull, opening this PR for discussion/review to see if it is worth developing further.) Replaces the Bukkit API dependency (GPLv3) with a [clean room MIT-licensed alternative](https://github.com/deathcap/BedrockAPI) written using the API documentation javadoc available at http://jd.bukkit.org/rb/apidocs/ for reference.

Relates to #148 #147 in that this would allow licensing the Glowstone binary distribution more permissively than GPL (assuming there are no other relevant dependencies).

Currently Glowstone with this change _compiles_ successfully (e.g., all the needed interfaces are present) but is not yet runnable, due to missing method implementations. However I suspect is feasible to reimplement these missing pieces, if there is interest — though primarily an API, "Bukkit" also includes some important utilities in org.bukkit.*:
- [ ] plugin loader (plugin.yml parsing, class loading)
