### PR TITLE
Switch to Netty ReadTimeoutHandler

### DIFF
--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -43,12 +43,6 @@ import java.util.logging.Level;
 public final class GlowSession extends BasicSession {
 
     /**
-     * The number of ticks which are elapsed before a client is disconnected due
-     * to a timeout.
-     */
-    private static final int TIMEOUT_TICKS = 300;
-
-    /**
      * The server this session belongs to.
      */
     private final GlowServer server;
@@ -89,22 +83,11 @@ public final class GlowSession extends BasicSession {
     private String hostname;
 
     /**
-     * A timeout counter. This is increment once every tick and if it goes above
-     * a certain value the session is disconnected.
-     */
-    private int readTimeoutCounter = 0;
-
-    /**
      * Data regarding a user who has connected through a proxy, used to
      * provide online-mode UUID and properties and other data even if the
      * server is running in offline mode. Null for non-proxied sessions.
      */
     private ProxyData proxyData;
-
-    /**
-     * Similar to readTimeoutCounter but for writes.
-     */
-    private int writeTimeoutCounter = 0;
 
     /**
      * The player associated with this session (if there is one).
@@ -207,12 +190,26 @@ public final class GlowSession extends BasicSession {
     }
 
     /**
+     * Notify that the session is currently idle.
+     */
+    public void idle() {
+        if (pingMessageId == 0 && getProtocol() instanceof PlayProtocol) {
+            pingMessageId = random.nextInt();
+            if (pingMessageId == 0) {
+                pingMessageId++;
+            }
+            send(new PingMessage(pingMessageId));
+        } else {
+            disconnect("Timed out");
+        }
+    }
+
+    /**
      * Note that the client has responded to a keep-alive.
      * @param pingId The pingId to check for validity.
      */
     public void pong(long pingId) {
         if (pingId == pingMessageId) {
-            readTimeoutCounter = 0;
             pingMessageId = 0;
         }
     }
@@ -320,7 +317,6 @@ public final class GlowSession extends BasicSession {
 
     @Override
     public ChannelFuture sendWithFuture(Message message) {
-        writeTimeoutCounter = 0;
         if (!isActive()) {
             // discard messages sent if we're closed, since this happens a lot
             return null;
@@ -389,9 +385,6 @@ public final class GlowSession extends BasicSession {
      * Pulse this session, performing any updates needed.
      */
     void pulse() {
-        readTimeoutCounter++;
-        writeTimeoutCounter++;
-
         // drop the previous placement if needed
         if (previousPlacementTicks > 0 && --previousPlacementTicks == 0) {
             previousPlacement = null;
@@ -406,24 +399,6 @@ public final class GlowSession extends BasicSession {
             }
 
             super.messageReceived(message);
-            readTimeoutCounter = 0;
-        }
-
-        // let us know if the client has timed out yet
-        if (readTimeoutCounter >= TIMEOUT_TICKS) {
-            if (pingMessageId == 0 && getProtocol() instanceof PlayProtocol) {
-                pingMessageId = random.nextInt();
-                send(new PingMessage(pingMessageId));
-            } else {
-                disconnect("Timed out");
-            }
-            readTimeoutCounter = 0;
-        }
-
-        // let the client know we haven't timed out yet
-        if (writeTimeoutCounter >= TIMEOUT_TICKS && getProtocol() instanceof PlayProtocol) {
-            pingMessageId = random.nextInt();
-            send(new PingMessage(pingMessageId));
         }
     }
 

--- a/src/main/java/net/glowstone/net/pipeline/GlowChannelInitializer.java
+++ b/src/main/java/net/glowstone/net/pipeline/GlowChannelInitializer.java
@@ -1,14 +1,30 @@
 package net.glowstone.net.pipeline;
 
 import com.flowpowered.networking.ConnectionManager;
+
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.handler.timeout.ReadTimeoutHandler;
 import net.glowstone.net.protocol.ProtocolType;
 
 /**
  * Used to initialize the channels.
  */
 public final class GlowChannelInitializer extends ChannelInitializer<SocketChannel> {
+
+    /**
+     * The time in seconds which are elapsed before a client is disconnected due 
+     * to a read timeout.
+     */
+    private static final int READ_TIMEOUT = 20;
+
+    /**
+     * The time in seconds which are elapsed before a client is deemed idle due 
+     * to a write timeout.
+     */
+    private static final int WRITE_IDLE_TIMEOUT = 15;
+
     private final ConnectionManager connectionManager;
 
     public GlowChannelInitializer(ConnectionManager connectionManager) {
@@ -26,6 +42,8 @@ public final class GlowChannelInitializer extends ChannelInitializer<SocketChann
                 .addLast("framing", framing)
                 .addLast("compression", NoopHandler.INSTANCE)
                 .addLast("codecs", codecs)
+                .addLast("readtimeout", new ReadTimeoutHandler(READ_TIMEOUT))
+                .addLast("writeidletimeout", new IdleStateHandler(0, WRITE_IDLE_TIMEOUT, 0))
                 .addLast("handler", handler);
     }
 }

--- a/src/main/java/net/glowstone/net/pipeline/MessageHandler.java
+++ b/src/main/java/net/glowstone/net/pipeline/MessageHandler.java
@@ -3,11 +3,15 @@ package net.glowstone.net.pipeline;
 import com.flowpowered.networking.ConnectionManager;
 import com.flowpowered.networking.Message;
 import com.flowpowered.networking.session.Session;
+
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.timeout.IdleStateEvent;
 
 import java.util.concurrent.atomic.AtomicReference;
+
+import net.glowstone.net.GlowSession;
 
 /**
  * Experimental pipeline component, based on flow-net's MessageHandler.
@@ -47,6 +51,13 @@ public final class MessageHandler extends SimpleChannelInboundHandler<Message> {
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, Message i) {
         session.get().messageReceived(i);
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof IdleStateEvent) {
+            ((GlowSession) session.get()).idle(); // todo: find a more elegant way to do this in the future
+        }
     }
 
     @Override


### PR DESCRIPTION
The current method we use to timeout clients is based on the server tickrate. We should not use that, and instead use something built-in to Netty to stay reliable.

This is a work in progress, as we should also implement a new method of accomplishing the ping-pong process that is asynchronous. My reasoning behind this is that even if the server stops ticking to do a large amount of logic, your client should not disconnect due to a read timeout like you do in vanilla.
