### PR TITLE
Handle status packets asynchronously

### DIFF
--- a/src/main/java/net/glowstone/net/message/status/StatusPingMessage.java
+++ b/src/main/java/net/glowstone/net/message/status/StatusPingMessage.java
@@ -1,8 +1,8 @@
 package net.glowstone.net.message.status;
 
-import com.flowpowered.networking.Message;
+import com.flowpowered.networking.AsyncableMessage;
 
-public final class StatusPingMessage implements Message {
+public final class StatusPingMessage implements AsyncableMessage {
 
     private final long time;
 
@@ -12,6 +12,11 @@ public final class StatusPingMessage implements Message {
 
     public long getTime() {
         return time;
+    }
+
+    @Override
+    public boolean isAsync() {
+        return true;
     }
 
 }

--- a/src/main/java/net/glowstone/net/message/status/StatusRequestMessage.java
+++ b/src/main/java/net/glowstone/net/message/status/StatusRequestMessage.java
@@ -8,5 +8,5 @@ public final class StatusRequestMessage implements AsyncableMessage {
     public boolean isAsync() {
         return true;
     }
-    
+
 }

--- a/src/main/java/net/glowstone/net/message/status/StatusRequestMessage.java
+++ b/src/main/java/net/glowstone/net/message/status/StatusRequestMessage.java
@@ -1,6 +1,12 @@
 package net.glowstone.net.message.status;
 
-import com.flowpowered.networking.Message;
+import com.flowpowered.networking.AsyncableMessage;
 
-public final class StatusRequestMessage implements Message {
+public final class StatusRequestMessage implements AsyncableMessage {
+
+    @Override
+    public boolean isAsync() {
+        return true;
+    }
+    
 }


### PR DESCRIPTION
Status packets are currently behind handled on the main thread. With this PR, they are moved off of the main thread and are handled by the NIO threads.

It is good to note however that ServerListPingEvent, although incorrectly documented, is an asynchronously fired event within currently available Bukkit implementations.
