### PR TITLE
Handle target blocks gracefully.

### DIFF
--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
@@ -14,7 +14,13 @@ public final class PlayerSwingArmHandler implements MessageHandler<GlowSession, 
     public void handle(GlowSession session, PlayerSwingArmMessage message) {
         final GlowPlayer player = session.getPlayer();
 
-        Block block = player.getTargetBlock(null, 6);
+        Block block;
+        try {
+            block = player.getTargetBlock(null, 6);
+        } catch (IllegalStateException ex) {
+            block = null;
+        }
+
         if (block == null || block.isEmpty()) {
             if (EventFactory.onPlayerInteract(player, Action.LEFT_CLICK_AIR).isCancelled())
                 return;


### PR DESCRIPTION
Sometimes, player.getTargetBlock() returns an IllegalStateException.
This is usually the case if players stand at height 127 and look up when left-clicking.
The exception can be safely caught and treated as an invalid block (air in this case).
