### PR TITLE
Let the player drop the (whole) ItemStack in his hand with (Ctrl+)Q

### DIFF
--- a/src/main/java/net/glowstone/EventFactory.java
+++ b/src/main/java/net/glowstone/EventFactory.java
@@ -7,7 +7,6 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.block.Action;
@@ -67,10 +66,6 @@ public final class EventFactory {
     ////////////////////////////////////////////////////////////////////////////
     // Player Events
 
-    public static PlayerDropItemEvent onPlayerDropItem(Player player, Item droppedItem) {
-        return callEvent(new PlayerDropItemEvent(player, droppedItem));
-    }
-    
     public static AsyncPlayerPreLoginEvent onPlayerPreLogin(String name, InetSocketAddress address, UUID uuid) {
         // call async event
         final AsyncPlayerPreLoginEvent event = new AsyncPlayerPreLoginEvent(name, address.getAddress(), uuid);

--- a/src/main/java/net/glowstone/EventFactory.java
+++ b/src/main/java/net/glowstone/EventFactory.java
@@ -7,6 +7,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.block.Action;
@@ -66,6 +67,10 @@ public final class EventFactory {
     ////////////////////////////////////////////////////////////////////////////
     // Player Events
 
+    public static PlayerDropItemEvent onPlayerDropItem(Player player, Item droppedItem) {
+        return callEvent(new PlayerDropItemEvent(player, droppedItem));
+    }
+    
     public static AsyncPlayerPreLoginEvent onPlayerPreLogin(String name, InetSocketAddress address, UUID uuid) {
         // call async event
         final AsyncPlayerPreLoginEvent event = new AsyncPlayerPreLoginEvent(name, address.getAddress(), uuid);

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -9,6 +9,7 @@ import net.glowstone.constants.*;
 import net.glowstone.entity.meta.ClientSettings;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.MetadataMap;
+import net.glowstone.entity.objects.GlowItem;
 import net.glowstone.entity.meta.profile.PlayerProfile;
 import net.glowstone.inventory.GlowInventory;
 import net.glowstone.inventory.InventoryMonitor;
@@ -1625,6 +1626,20 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         }
 
         updateInventory();
+    }
+
+    @Override
+    public GlowItem drop(ItemStack stack) {
+        GlowItem dropping = super.drop(stack);
+        if (dropping != null) {
+            PlayerDropItemEvent event = new PlayerDropItemEvent(this, dropping);
+            EventFactory.callEvent(event);
+            if (event.isCancelled()) {
+                dropping.remove();
+                dropping = null;
+            }
+        }
+        return dropping;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/net/handler/play/inv/CloseWindowHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/CloseWindowHandler.java
@@ -4,7 +4,6 @@ import com.flowpowered.networking.MessageHandler;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.inv.CloseWindowMessage;
-import org.bukkit.GameMode;
 
 public final class CloseWindowHandler implements MessageHandler<GlowSession, CloseWindowMessage> {
     @Override
@@ -13,14 +12,7 @@ public final class CloseWindowHandler implements MessageHandler<GlowSession, Clo
 
         // todo: drop items from workbench, enchant inventory, own crafting grid if needed
 
+        //Drop item on cursor, set it to null afterwards
         player.closeInventory();
-
-        if (player.getItemOnCursor() != null) {
-            // player.getWorld().dropItem(player.getEyeLocation(), player.getItemInHand());
-            if (player.getGameMode() != GameMode.CREATIVE) {
-                player.getInventory().addItem(player.getItemOnCursor());
-            }
-            player.setItemOnCursor(null);
-        }
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/inv/CreativeItemHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/CreativeItemHandler.java
@@ -6,6 +6,7 @@ import net.glowstone.inventory.GlowInventoryView;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.inv.CreativeItemMessage;
 import org.bukkit.GameMode;
+import org.bukkit.inventory.ItemStack;
 
 public final class CreativeItemHandler implements MessageHandler<GlowSession, CreativeItemMessage> {
     @Override
@@ -25,7 +26,8 @@ public final class CreativeItemHandler implements MessageHandler<GlowSession, Cr
         }
 
         if (message.getSlot() < 0) {
-            // todo: drop outside
+            ItemStack dropping = message.getItem();
+            player.drop(dropping);
             return;
         }
 

--- a/src/main/java/net/glowstone/net/handler/play/inv/WindowClickHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/WindowClickHandler.java
@@ -17,7 +17,6 @@ import org.bukkit.event.inventory.*;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.util.Vector;
 
 import java.util.HashMap;
 import java.util.List;
@@ -343,9 +342,7 @@ public final class WindowClickHandler implements MessageHandler<GlowSession, Win
             return;
         }
         // drop item with the given contents and throw it the way the player is facing
-        // this 0.2 number has been pulled out of thin air
-        Vector vel = player.getLocation().getDirection().multiply(0.2);
-        player.getWorld().dropItem(player.getEyeLocation(), stack).setVelocity(vel);
+        player.drop(stack);
     }
 
     private ItemStack combine(ItemStack slotItem, ItemStack cursor, int amount) {

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -5,24 +5,19 @@ import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.GlowPlayer;
-import net.glowstone.entity.objects.GlowItem;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.DiggingMessage;
 import org.bukkit.Effect;
 import org.bukkit.GameMode;
-import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.enchantments.EnchantmentTarget;
-import org.bukkit.entity.Item;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
-import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.util.Vector;
 
 public final class DiggingHandler implements MessageHandler<GlowSession, DiggingMessage> {
     @Override
@@ -76,10 +71,10 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
             // because a player's digging status isn't yet tracked. this is bad.
             blockBroken = true;
         } else if (message.getState() == DiggingMessage.STATE_DROP_ITEM) {
-            drop(player, true);
+            player.dropItemInHand(false);
             return;
         } else if (message.getState() == DiggingMessage.STATE_DROP_ITEMSTACK) {
-            drop(player, false);
+            player.dropItemInHand(true);
             return;
         } else {
             return;
@@ -105,35 +100,6 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
         } else if (revert) {
             // replace the block that wasn't really dug
             BlockPlacementHandler.revert(player, block);
-        }
-    }
-
-    private void drop(GlowPlayer player, boolean onlyOneItem) {
-        ItemStack itemInHand = player.getItemInHand();
-        if (itemInHand == null || itemInHand.getAmount() == 0)
-            return;
-
-        ItemStack dropItemStack = itemInHand.clone();
-        if (onlyOneItem)
-            dropItemStack.setAmount(1);
-
-        Location dropLocation = player.getLocation().clone();
-        dropLocation.add(0, -0.3D + player.getEyeHeight(true), 0);
-        Item dropItem = new GlowItem(dropLocation, dropItemStack);
-        Vector vel = player.getLocation().getDirection().multiply(0.3f);
-        vel.setY(vel.getY() + 0.1F);
-        dropItem.setVelocity(vel);
-
-        PlayerDropItemEvent event = EventFactory.onPlayerDropItem(player, dropItem);
-        if (event.isCancelled()) {
-            dropItem.remove();
-        } else {
-            if (!onlyOneItem || itemInHand.getAmount() == 1) {
-                player.setItemInHand(null);
-            } else {
-                itemInHand.setAmount(itemInHand.getAmount() - 1);
-                player.setItemInHand(itemInHand);
-            }
         }
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -5,19 +5,24 @@ import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.GlowPlayer;
+import net.glowstone.entity.objects.GlowItem;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.DiggingMessage;
 import org.bukkit.Effect;
 import org.bukkit.GameMode;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.enchantments.EnchantmentTarget;
+import org.bukkit.entity.Item;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
 
 public final class DiggingHandler implements MessageHandler<GlowSession, DiggingMessage> {
     @Override
@@ -70,6 +75,12 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
             // also, if the block dig was denied, this break might still happen
             // because a player's digging status isn't yet tracked. this is bad.
             blockBroken = true;
+        } else if (message.getState() == DiggingMessage.STATE_DROP_ITEM) {
+            drop(player, true);
+            return;
+        } else if (message.getState() == DiggingMessage.STATE_DROP_ITEMSTACK) {
+            drop(player, false);
+            return;
         } else {
             return;
         }
@@ -94,6 +105,35 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
         } else if (revert) {
             // replace the block that wasn't really dug
             BlockPlacementHandler.revert(player, block);
+        }
+    }
+
+    private void drop(GlowPlayer player, boolean onlyOneItem) {
+        ItemStack itemInHand = player.getItemInHand();
+        if (itemInHand == null || itemInHand.getAmount() == 0)
+            return;
+
+        ItemStack dropItemStack = itemInHand.clone();
+        if (onlyOneItem)
+            dropItemStack.setAmount(1);
+
+        Location dropLocation = player.getLocation().clone();
+        dropLocation.add(0, -0.3D + player.getEyeHeight(true), 0);
+        Item dropItem = new GlowItem(dropLocation, dropItemStack);
+        Vector vel = player.getLocation().getDirection().multiply(0.3f);
+        vel.setY(vel.getY() + 0.1F);
+        dropItem.setVelocity(vel);
+
+        PlayerDropItemEvent event = EventFactory.onPlayerDropItem(player, dropItem);
+        if (event.isCancelled()) {
+            dropItem.remove();
+        } else {
+            if (!onlyOneItem || itemInHand.getAmount() == 1) {
+                player.setItemInHand(null);
+            } else {
+                itemInHand.setAmount(itemInHand.getAmount() - 1);
+                player.setItemInHand(itemInHand);
+            }
         }
     }
 }

--- a/src/main/java/net/glowstone/net/message/play/player/DiggingMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/player/DiggingMessage.java
@@ -8,6 +8,7 @@ public final class DiggingMessage implements Message {
 
     public static final int START_DIGGING = 0;
     public static final int FINISH_DIGGING = 2;
+    public static final int STATE_DROP_ITEMSTACK = 3;
     public static final int STATE_DROP_ITEM = 4;
 
     private final int state, x, y, z, face;


### PR DESCRIPTION
When you press (Ctrl+)Q in minecraft, you are able to drop the (whole) ItemStack, just like if you drag and drop it out of your inventory.
