### PR TITLE
Chest animations (Open/Close)

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockChest.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockChest.java
@@ -2,17 +2,22 @@ package net.glowstone.block.blocktype;
 
 import net.glowstone.GlowChunk;
 import net.glowstone.GlowServer;
+import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.TEChest;
+import net.glowstone.block.entity.TEContainer;
 import net.glowstone.block.entity.TileEntity;
+import net.glowstone.block.state.GlowChest;
 import net.glowstone.entity.GlowPlayer;
+
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.NoteBlock;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.Chest;
 import org.bukkit.material.MaterialData;
 import org.bukkit.util.Vector;
 
-public class BlockChest extends BlockContainer {
+public class BlockChest extends BlockType {
 
     @Override
     public TileEntity createTileEntity(GlowChunk chunk, int cx, int cy, int cz) {
@@ -33,4 +38,26 @@ public class BlockChest extends BlockContainer {
             GlowServer.logger.warning("Placing Chest: MaterialData was of wrong type");
         }
     }
+    
+    @Override
+    public boolean blockInteract(GlowPlayer player, GlowBlock block, BlockFace face, Vector clickedLoc) {
+    	 TileEntity te = block.getTileEntity();
+         if (te instanceof TEContainer) {
+             player.openInventory(((TEContainer) te).getInventory());
+             //Only open when chest is closed player interacts, only close when player closes chest inventory
+             if (((GlowChest) block.getState()).getState() == 0)
+             {
+            	 player.SetBindChest(block.getLocation());
+            	 ((GlowChest) block.getState()).setState((byte)1);
+            	 ((GlowChest) block.getState()).ChestAnimation((byte)1);
+             }
+             
+             return true;
+         }
+		return false;
+    	
+    }
+  
+    
+    
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockChest.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockChest.java
@@ -45,8 +45,7 @@ public class BlockChest extends BlockType {
          if (te instanceof TEContainer) {
              player.openInventory(((TEContainer) te).getInventory());
              //Only open when chest is closed player interacts, only close when player closes chest inventory
-             if (((GlowChest) block.getState()).getState() == 0)
-             {
+             if (((GlowChest) block.getState()).getState() == 0){
             	 player.SetBindChest(block.getLocation());
             	 ((GlowChest) block.getState()).setState((byte)1);
             	 ((GlowChest) block.getState()).ChestAnimation((byte)1);

--- a/src/main/java/net/glowstone/block/state/GlowChest.java
+++ b/src/main/java/net/glowstone/block/state/GlowChest.java
@@ -1,15 +1,22 @@
 package net.glowstone.block.state;
 
+import net.glowstone.GlowChunk;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.TEChest;
+import net.glowstone.entity.GlowPlayer;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Chest;
 import org.bukkit.inventory.Inventory;
 
 public class GlowChest extends GlowBlockState implements Chest {
 
+	public int state;
     public GlowChest(GlowBlock block) {
         super(block);
+        state = 0;
     }
 
     private TEChest getTileEntity() {
@@ -26,4 +33,31 @@ public class GlowChest extends GlowBlockState implements Chest {
         // todo: handle double chests
         return getBlockInventory();
     }
+    
+    //closed 0, open 1
+    public int getState() {
+        return this.state;
+    }
+    
+    public void setState(Byte state) {
+        this.state = state;
+    }
+    
+    public boolean ChestAnimation(byte state) {
+        if (getBlock().getType() != Material.CHEST) {
+            return false;
+        }
+
+        Location location = getBlock().getLocation();
+
+        GlowChunk.Key key = new GlowChunk.Key(getX() >> 4, getZ() >> 4);
+        for (GlowPlayer player : getWorld().getRawPlayers()) {
+            if (player.canSee(key)) {
+                player.playChestAnimation(location, state);
+            }
+        }
+
+        return true;
+    }
+    
 }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -232,6 +232,12 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
      * The player's base walking speed.
      */
     private float walkSpeed = 0.2f;
+    
+    /**
+     * If the player currently has an open chest.
+     */
+    private Location bindchest;
+
 
     /**
      * Creates a new player and adds it to the world.
@@ -1165,6 +1171,18 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         session.send(new BlockActionMessage(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ(), instrument, note, Material.NOTE_BLOCK.getId()));
     }
 
+    public Location GetBindChest() {
+    	return bindchest;
+    }
+    
+    public void SetBindChest(Location loc) {
+    	bindchest = loc;
+    }
+    
+    public void playChestAnimation(Location loc, byte state) {
+        session.send(new BlockActionMessage(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ(), (byte) 1, state, Material.CHEST.getId()));
+    }
+    
     public void playEffect(Location loc, Effect effect, int data) {
         int id = effect.getId();
         boolean ignoreDistance = id == 1013; // mob.wither.spawn, not in Bukkit yet

--- a/src/main/java/net/glowstone/net/handler/play/inv/CloseWindowHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/CloseWindowHandler.java
@@ -29,8 +29,7 @@ public final class CloseWindowHandler implements MessageHandler<GlowSession, Clo
             player.setItemOnCursor(null);
         }
         
-        if (player.GetBindChest() != null)
-        {
+        if (player.GetBindChest() != null){  
         	World world = player.getWorld();
         	Block bl = world.getBlockAt(player.GetBindChest());
         	

--- a/src/main/java/net/glowstone/net/handler/play/inv/CloseWindowHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/CloseWindowHandler.java
@@ -1,10 +1,17 @@
 package net.glowstone.net.handler.play.inv;
 
 import com.flowpowered.networking.MessageHandler;
+
+import net.glowstone.GlowServer;
+import net.glowstone.block.state.GlowChest;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.inv.CloseWindowMessage;
+
 import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
 
 public final class CloseWindowHandler implements MessageHandler<GlowSession, CloseWindowMessage> {
     public void handle(GlowSession session, CloseWindowMessage message) {
@@ -20,6 +27,19 @@ public final class CloseWindowHandler implements MessageHandler<GlowSession, Clo
                 player.getInventory().addItem(player.getItemOnCursor());
             }
             player.setItemOnCursor(null);
+        }
+        
+        if (player.GetBindChest() != null)
+        {
+        	World world = player.getWorld();
+        	Block bl = world.getBlockAt(player.GetBindChest());
+        	
+        	if (bl.getType() == Material.CHEST)
+        	{
+	       	((GlowChest) bl.getState()).setState((byte)0);
+	       	((GlowChest) bl.getState()).ChestAnimation((byte)0);
+        	player.SetBindChest(null);
+        	}
         }
     }
 }


### PR DESCRIPTION
Sends the chest open and close animations. Tested, works as intended. Player can only open an unopened chest. Chest only closes when the player leaves the chest inventory.
