### PR TITLE
Rogue threads are completely obliterated now

### DIFF
--- a/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
+++ b/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
@@ -4,7 +4,6 @@ import net.glowstone.GlowServer;
 
 import java.util.Map;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Thread started on shutdown that monitors for and kills rogue non-daemon threads.
@@ -42,18 +41,20 @@ public class ShutdownMonitorThread extends Thread {
                 continue;
             }
 
-            GlowServer.logger.warning("Rogue thread: " + thread.toString());
+            GlowServer.logger.log(Level.WARNING, "Rogue thread: {0}", thread);
             for (StackTraceElement trace : stack) {
-                GlowServer.logger.warning("\tat " + trace.toString());
+                GlowServer.logger.log(Level.WARNING, "\tat {0}", trace);
             }
 
             // ask nicely to kill them
             thread.interrupt();
             // wait for them to die on their own
-            try {
-                thread.join(1000);
-            } catch (InterruptedException ex) {
-                GlowServer.logger.severe(ex.toString());
+            if(thread.isAlive()){
+                try {
+                    thread.join(1000);
+                } catch (InterruptedException ex) {
+                    GlowServer.logger.log(Level.SEVERE, ex.getMessage(), ex);
+                }
             }
         }
         // kill them forcefully

--- a/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
+++ b/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
@@ -45,11 +45,11 @@ public class ShutdownMonitorThread extends Thread {
                 GlowServer.logger.warning("\tat " + trace.toString());
             }
 
-            //ask nicely to kill them
+            // ask nicely to kill them
             thread.interrupt();
         }
-        //kill them forcefully
+        // kill them forcefully
         System.exit(1000);
     }
-    
+
 }

--- a/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
+++ b/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
@@ -1,10 +1,11 @@
 package net.glowstone.util;
 
+import net.glowstone.GlowServer;
+
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import net.glowstone.GlowServer;
 
 /**
  * Thread started on shutdown that monitors for and kills rogue non-daemon threads.
@@ -20,13 +21,12 @@ public class ShutdownMonitorThread extends Thread {
      * Toggle for if ShutdownMonitor should be sleeping threads.
      */
     private volatile boolean run;
-    
+
     private ExecutorService execute;
-    
+
     public ShutdownMonitorThread() {
         setName("ShutdownMonitorThread");
         setDaemon(true);
-        
     }
 
     @Override
@@ -41,9 +41,9 @@ public class ShutdownMonitorThread extends Thread {
                 return;
             }
         }
-        
+
         GlowServer.logger.warning("Still running after shutdown, finding rogue threads...");
-        
+
         final Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
         for (Map.Entry<Thread, StackTraceElement[]> entry : traces.entrySet()) {
             final Thread thread = entry.getKey();
@@ -65,11 +65,8 @@ public class ShutdownMonitorThread extends Thread {
                 } catch (InterruptedException ex) {
                     Logger.getLogger(ShutdownMonitorThread.class.getName()).log(Level.SEVERE, null, ex);
                 }
-                
-                
         }
             //stop the scheduler and tasks
             execute.shutdownNow();
     }
-
 }

--- a/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
+++ b/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
@@ -3,6 +3,8 @@ package net.glowstone.util;
 import net.glowstone.GlowServer;
 
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Thread started on shutdown that monitors for and kills rogue non-daemon threads.
@@ -47,6 +49,12 @@ public class ShutdownMonitorThread extends Thread {
 
             // ask nicely to kill them
             thread.interrupt();
+            // wait for them to die on their own
+            try {
+                thread.join(1000);
+            } catch (InterruptedException ex) {
+                GlowServer.logger.severe(ex.toString());
+            }
         }
         // kill them forcefully
         System.exit(0);

--- a/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
+++ b/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
@@ -49,7 +49,7 @@ public class ShutdownMonitorThread extends Thread {
             // ask nicely to kill them
             thread.interrupt();
             // wait for them to die on their own
-            if(thread.isAlive()){
+            if (thread.isAlive()) {
                 try {
                     thread.join(1000);
                 } catch (InterruptedException ex) {

--- a/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
+++ b/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
@@ -49,7 +49,7 @@ public class ShutdownMonitorThread extends Thread {
             thread.interrupt();
         }
         // kill them forcefully
-        System.exit(1000);
+        System.exit(0);
     }
 
 }

--- a/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
+++ b/src/main/java/net/glowstone/util/ShutdownMonitorThread.java
@@ -21,31 +21,35 @@ public class ShutdownMonitorThread extends Thread {
 
     @Override
     public void run() {
-            try {
-                Thread.sleep(DELAY);
-            } catch (InterruptedException e) {
-                GlowServer.logger.severe("ShutdownMonitor interrupted");
-                return;
-            }
+        try {
+            Thread.sleep(DELAY);
+        } catch (InterruptedException e) {
+            GlowServer.logger.severe("ShutdownMonitor interrupted");
+            return;
+        }
 
         GlowServer.logger.warning("Still running after shutdown, finding rogue threads...");
 
-        Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
+        final Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
         for (Map.Entry<Thread, StackTraceElement[]> entry : traces.entrySet()) {
-            Thread thread = entry.getKey();
-            StackTraceElement[] stack = entry.getValue();
+            final Thread thread = entry.getKey();
+            final StackTraceElement[] stack = entry.getValue();
+
             if (thread.isDaemon() || !thread.isAlive() || stack.length == 0) {
                 // won't keep JVM from exiting
                 continue;
             }
+
             GlowServer.logger.warning("Rogue thread: " + thread.toString());
             for (StackTraceElement trace : stack) {
                 GlowServer.logger.warning("\tat " + trace.toString());
             }
+
             //ask nicely to kill them
             thread.interrupt();
         }
         //kill them forcefully
         System.exit(1000);
     }
+    
 }


### PR DESCRIPTION
Added better logic for thread sleeping, better rogue thread stopping, and finally, the shutdown thread stops the scheduler and any remaining tasks. Planning to add a graceful shutdown for scheduling later. (where it stops any new tasks from being created, then waits for any current tasks to be completed for a second or two, and then forcefully shuts down now)
Fixes #179 
