### PR TITLE
Redstone framework

### DIFF
--- a/src/main/java/net/glowstone/ChunkManager.java
+++ b/src/main/java/net/glowstone/ChunkManager.java
@@ -119,7 +119,7 @@ public final class ChunkManager {
         try {
             if (service.read(chunk)) {
                 EventFactory.onChunkLoad(chunk, false);
-                world.getRSManager().dirtyRedChunk(x, z);
+                world.getRSManager().dirtyChunk(x, z);
                 return true;
             }
         } catch (Exception e) {

--- a/src/main/java/net/glowstone/ChunkManager.java
+++ b/src/main/java/net/glowstone/ChunkManager.java
@@ -119,6 +119,7 @@ public final class ChunkManager {
         try {
             if (service.read(chunk)) {
                 EventFactory.onChunkLoad(chunk, false);
+                world.getRSManager().dirtyRedChunk(x, z);
                 return true;
             }
         } catch (Exception e) {

--- a/src/main/java/net/glowstone/GlowChunk.java
+++ b/src/main/java/net/glowstone/GlowChunk.java
@@ -473,7 +473,7 @@ public final class GlowChunk implements Chunk {
         createEntity(x, y, z, type);
 
         // tell the redstone manager that this block has changed
-        world.getRSManager().dirtyRedBlock((this.x<<4)+x, y, (this.z<<4)+z);
+        world.getRSManager().dirtyBlock((this.x<<4)+x, y, (this.z<<4)+z);
     }
 
     /**
@@ -504,7 +504,7 @@ public final class GlowChunk implements Chunk {
         int type = section.types[index];
         if (type == 0) return;  // can't set metadata on air
         section.types[index] = (char) ((type & 0xfff0) | metaData);
-        world.getRSManager().dirtyRedBlock((this.x<<4)+x, y, (this.z<<4)+z);
+        world.getRSManager().dirtyBlock((this.x<<4)+x, y, (this.z<<4)+z);
     }
 
     /**

--- a/src/main/java/net/glowstone/GlowChunk.java
+++ b/src/main/java/net/glowstone/GlowChunk.java
@@ -472,8 +472,8 @@ public final class GlowChunk implements Chunk {
         // create a new tile entity if we need
         createEntity(x, y, z, type);
 
-        // tell the redstone manager that this chunk is dirty
-        world.getRSManager().dirtyRedChunk(this.x, this.z);
+        // tell the redstone manager that this block has changed
+        world.getRSManager().dirtyRedBlock((this.x<<4)+x, y, (this.z<<4)+z);
     }
 
     /**
@@ -504,7 +504,7 @@ public final class GlowChunk implements Chunk {
         int type = section.types[index];
         if (type == 0) return;  // can't set metadata on air
         section.types[index] = (char) ((type & 0xfff0) | metaData);
-        world.getRSManager().dirtyRedChunk(this.x, this.z);
+        world.getRSManager().dirtyRedBlock((this.x<<4)+x, y, (this.z<<4)+z);
     }
 
     /**

--- a/src/main/java/net/glowstone/GlowChunk.java
+++ b/src/main/java/net/glowstone/GlowChunk.java
@@ -471,6 +471,9 @@ public final class GlowChunk implements Chunk {
 
         // create a new tile entity if we need
         createEntity(x, y, z, type);
+
+        // tell the redstone manager that this chunk is dirty
+        world.getRSManager().dirtyRedChunk(this.x, this.z);
     }
 
     /**
@@ -501,6 +504,7 @@ public final class GlowChunk implements Chunk {
         int type = section.types[index];
         if (type == 0) return;  // can't set metadata on air
         section.types[index] = (char) ((type & 0xfff0) | metaData);
+        world.getRSManager().dirtyRedChunk(this.x, this.z);
     }
 
     /**

--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -1358,4 +1358,4 @@ public final class GlowWorld implements World {
         }
         return result;
     }
-} 
+}

--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -869,7 +869,9 @@ public final class GlowWorld implements World {
     @Override
     public boolean unloadChunk(int x, int z, boolean save, boolean safe) {
         boolean success = (!isChunkLoaded(x, z) || getChunkAt(x, z).unload(save, safe));
-        if(success) { getRSManager().dropRedChunk(x, z); }
+        if(success) {
+            getRSManager().dropChunk(x, z);
+        }
         return success;
     }
 
@@ -915,7 +917,7 @@ public final class GlowWorld implements World {
             }
         }
 
-        getRSManager().dirtyRedChunk(x, z);
+        getRSManager().dirtyChunk(x, z);
 
         return result;
     }

--- a/src/main/java/net/glowstone/RSManager.java
+++ b/src/main/java/net/glowstone/RSManager.java
@@ -1,0 +1,301 @@
+package net.glowstone;
+
+import net.glowstone.GlowServer;
+import net.glowstone.GlowWorld;
+import java.util.*;
+
+/**
+ * A class to manage redstone logic for a world.
+ * @author Ben Russell
+ */
+public class RSManager
+{
+    /**
+     * A manual enumeration of block types.
+     * TODO: Something better, perhaps?
+     */
+    public final int B_AIR = 0;
+    public final int B_SOLID = 1;
+    public final int B_RWIRE = 2;
+    public final int B_RTORCH = 3;
+    public final int B_RDIODE = 4; // Not supported yet
+
+    /**
+     * An immutable class for storing 3D world positions.
+     * TODO: Consider using Location (assuming it's hashable to the nearest int^3)
+     */
+    public final class RSPos
+    {
+        public final int x, y, z;
+
+        public RSPos(int x, int y, int z)
+        {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int hash = 1;
+
+            hash = hash * 31 + this.y;
+            hash = hash * 53 + this.x;
+            hash = hash * 19 + this.z;
+
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if(o instanceof RSPos)
+            {
+                RSPos op = (RSPos)o;
+
+                return true
+                    && op.x == this.x
+                    && op.y == this.y
+                    && op.z == this.z;
+
+            }
+
+            return false;
+        }
+
+        @Override
+        public String toString()
+        {
+            return String.format("RSPos(%d, %d, %d)", x, y, z);
+        }
+    }
+
+    /**
+     * The world this manager is assigned to.
+     */
+    private GlowWorld world;
+
+    /**
+     * Various redstone-related sets, maps and lists.
+     */ 
+    private HashSet<RSPos> redTorches = new HashSet<RSPos>();
+    private HashSet<RSPos> redSources = new HashSet<RSPos>();
+    private ArrayList<RSPos> redChargedWires = new ArrayList<RSPos>();
+    private HashSet<RSPos> redSinks = new HashSet<RSPos>();
+    private HashMap<RSPos, byte[]> redTypes = new HashMap<RSPos, byte[]>();
+    private HashMap<RSPos, byte[]> redMeta = new HashMap<RSPos, byte[]>();
+    private HashSet<RSPos> chunksDirty = new HashSet<RSPos>();
+    private HashSet<RSPos> chunksDirtyBack = new HashSet<RSPos>();
+
+    /**
+     * Create a new RS manager for a world.
+     * @param world The world this manager pertains to
+     */
+    public RSManager(GlowWorld world)
+    {
+        this.world = world;
+        // TODO: Get a list of chunks and mark the loaded ones as dirty
+    }
+
+    /**
+     * Sets the charge of a given block.
+     * @param x
+     * @param y
+     * @param z
+     * @param charged Whether this block is charged or not
+     */
+    private void setBlockCharge(int x, int y, int z, boolean charged)
+    {
+        // TODO!
+    }
+
+    /**
+     * Drops a redstone chunk out of the network.
+     * @param chunkX
+     * @param chunkZ
+     */
+    public synchronized void dropRedChunk(int chunkX, int chunkZ)
+    {
+        // TODO: Check if we need to prevent double-removals of a chunk
+        RSPos cp = new RSPos(chunkX, 0, chunkZ);
+
+        // Delete redTypes/redMeta
+        redTypes.remove(cp);
+        redMeta .remove(cp);
+
+        //System.out.println(String.format("red chunk !DROP! %d %d", chunkX, chunkZ));
+
+        // Loop
+        for(int y = 0; y < 256; y++)
+        for(int z = 0; z < 16; z++)
+        for(int x = 0; x < 16; x++)
+        {
+            // Get position
+            int rx = x + (chunkX << 4);
+            int ry = y;
+            int rz = z + (chunkZ << 4);
+            RSPos p = new RSPos(rx, ry, rz);
+
+            // Remove this from all appropriate sets
+            redTorches.remove(p);
+            redSources.remove(p);
+            redSinks.remove(p);
+        }
+    }
+
+    /**
+     * Marks a chunk as dirty so the redstone manager can update it.
+     * @param chunkX
+     * @param chunkZ
+     */
+    public synchronized void dirtyRedChunk(int chunkX, int chunkZ)
+    {
+        chunksDirty.add(new RSPos(chunkX, 0, chunkZ));
+    }
+
+    /**
+     * Updates the redstone state for a chunk.
+     * @param chunkX
+     * @param chunkZ
+     */
+    private synchronized void updateRedChunk(int chunkX, int chunkZ)
+    {
+        //System.out.println(String.format("red chunk update %d %d", chunkX, chunkZ));
+        RSPos cp = new RSPos(chunkX, 0, chunkZ);
+
+        // Fetch IDs and metadata
+        byte[] blockIDs  = (redTypes.containsKey(cp) ? redTypes.get(cp) : new byte[16*16*256]);
+        byte[] blockMeta = (redMeta .containsKey(cp) ? redMeta .get(cp) : new byte[16*16*256]);
+
+        // Loop
+        for(int pos = 0, y = 0; y < 256; y++)
+        for(int z = 0; z < 16; z++)
+        for(int x = 0; x < 16; x++, pos++)
+        {
+            // Get type from chunk (TODO!)
+            int type = B_AIR;
+            int meta = 0x00;
+            boolean charged = false;
+
+            // Write type
+            blockIDs[pos]  = (byte)type;
+            blockMeta[pos] = (byte)meta;
+
+            // Get position
+            int rx = x + (chunkX << 4);
+            int ry = y;
+            int rz = z + (chunkZ << 4);
+            RSPos p = new RSPos(rx, ry, rz);
+
+            // Remove this from all appropriate sets
+            redTorches.remove(p);
+            redSources.remove(p);
+            redSinks.remove(p);
+
+            switch(type)
+            {
+                case B_AIR:
+                    // Air is never a source
+                    break;
+
+                case B_RWIRE:
+                    // Wire isn't actually used at this step
+                    break;
+
+                case B_RTORCH:
+                    // Add this to the torches AND charges AND sources
+                    p = new RSPos(rx, ry, rz);
+                    redTorches.add(p);
+                    if(!charged) redSources.add(p);
+                    break;
+
+                case B_SOLID:
+                    // Add this to the charges AND sources
+                    p = new RSPos(rx, ry, rz);
+                    if(charged) redSources.add(p);
+                    break;
+
+            }
+        }
+
+        // Update redTypes and redMeta
+        redTypes.put(cp, blockIDs );
+        redMeta .put(cp, blockMeta);
+    }
+
+    /**
+     * Determine if a given chunk is loaded or not.
+     */
+    private boolean isChunkLoaded(int x, int z)
+    {
+        return world.isChunkLoaded(x, z);
+    }
+
+    /**
+     * Update all the redstone logic in the manager's assigned world.
+     */
+    public synchronized void pulse()
+    {
+        // Swap chunksDirty buffers
+        HashSet<RSPos> cdtemp = chunksDirty;
+        chunksDirty = chunksDirtyBack;
+        chunksDirtyBack = cdtemp;
+
+        // Clear dirty chunks
+        chunksDirty.clear();
+
+        // Update all dirty chunks
+        for(RSPos p : chunksDirtyBack)
+        {
+            // Skip unloaded chunks
+            if(!isChunkLoaded(p.x, p.z)) continue;
+
+            // Update RS chunk
+            updateRedChunk(p.x, p.z);
+        }
+
+        // Clear sinks
+        redSinks.clear();
+
+        // Discharge wires
+        for(RSPos p : redChargedWires)
+            setBlockCharge(p.x, p.y, p.z, false);
+
+        redChargedWires.clear();
+
+        // Lead sources to sinks
+        // TODO: Integrate properly
+        /*
+        for(RSPos p : redSources)
+            traceRedStart(p.x, p.y, p.z);
+        */
+
+        // Discharge sources
+        for(RSPos p : redSources)
+            setBlockCharge(p.x, p.y, p.z, false);
+
+        // Charge sinks
+        for(RSPos p : redSinks)
+            setBlockCharge(p.x, p.y, p.z, true);
+
+        // Charge wires
+        for(RSPos p : redChargedWires)
+            setBlockCharge(p.x, p.y, p.z, true);
+
+        // Flip sinks for torches
+        for(RSPos p : redTorches)
+        {
+            if(redSinks.contains(p))
+                redSinks.remove(p);
+            else
+                redSinks.add(p);
+        }
+
+        // Swap RS sources and sinks
+        HashSet<RSPos> rstemp = redSources;
+        redSources = redSinks;
+        redSinks = rstemp;
+    }
+}
+

--- a/src/main/java/net/glowstone/RSManager.java
+++ b/src/main/java/net/glowstone/RSManager.java
@@ -185,11 +185,21 @@ public class RSManager {
      * @param isDirect Whether we are applying direct or indirect power.
      */
     public void traceFromBlockToBlock(GlowBlock srcBlock, GlowBlock destBlock, BlockFace flowDir, int inPower, boolean isDirect) {
+        if(srcBlock == null) {
+            return;
+        }
+        if(destBlock == null) {
+            return;
+        }
+
         // Get source material
         Material srcMat = srcBlock.getType();
 
         // Get destination block data
         Material destMat = destBlock.getType();
+        if(destMat == null) {
+            return;
+        }
         BlockType destType = ItemTable.instance().getBlock(destMat);
         if(destType == null) {
             return;

--- a/src/main/java/net/glowstone/RSManager.java
+++ b/src/main/java/net/glowstone/RSManager.java
@@ -349,7 +349,11 @@ public class RSManager {
             if(block == null) {
                 continue;
             }
-            BlockType type = ItemTable.instance().getBlock(block.getType());
+            Material mat = block.getType();
+            if(mat == null) {
+                continue;
+            }
+            BlockType type = ItemTable.instance().getBlock(mat);
 
             // Check if we can add this as a source
             if(type != null && type.isRedSource(block)) {

--- a/src/main/java/net/glowstone/RSManager.java
+++ b/src/main/java/net/glowstone/RSManager.java
@@ -2,6 +2,12 @@ package net.glowstone;
 
 import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
+import net.glowstone.block.GlowBlock;
+import net.glowstone.block.ItemTable;
+import net.glowstone.block.blocktype.BlockType;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import java.util.*;
 
 /**
@@ -10,23 +16,20 @@ import java.util.*;
  */
 public class RSManager {
     /**
-     * An enum of block types.
+     * A flag used to enable testing redstone by spamming the console.
+     * Best to only enable this if you are a developer.
      */
-    // TODO: Change this to use BlockType instead
-    public enum RSBlock {
-        B_AIR,
-        B_SOLID,
-        B_RWIRE,
-        B_RTORCH,
-        B_RDIODE, // Not supported yet
-    }
+    public static final boolean DEBUG_REDSTONE = false;
 
     /**
      * An immutable class for storing 3D world positions.
-     * TODO: Consider using Location (assuming it's hashable to the nearest int^3)
      */
     public final class RSPos {
         public final int x, y, z;
+
+        public RSPos(Block block) {
+            this(block.getX(), block.getY(), block.getZ());
+        }
 
         public RSPos(int x, int y, int z) {
             this.x = x;
@@ -74,12 +77,14 @@ public class RSManager {
     /**
      * Various redstone-related sets, maps and lists.
      */ 
-    private Set<RSPos> redTorches = new HashSet<RSPos>();
-    private Set<RSPos> redSources = new HashSet<RSPos>();
-    private List<RSPos> redChargedWires = new ArrayList<RSPos>();
-    private Set<RSPos> redSinks = new HashSet<RSPos>();
-    private Set<RSPos> chunksDirty = new HashSet<RSPos>();
-    private Set<RSPos> chunksDirtyBack = new HashSet<RSPos>();
+    private Map<RSPos,Integer> redChargeNew = new HashMap<RSPos,Integer>();
+    private Map<RSPos,Integer> redChargeOld = new HashMap<RSPos,Integer>();
+    private Set<RSPos> redSourceNew = new HashSet<RSPos>();
+    private Set<RSPos> redSourceOld = new HashSet<RSPos>();
+    private Set<RSPos> chunksDirtyNew = new HashSet<RSPos>();
+    private Set<RSPos> chunksDirtyOld = new HashSet<RSPos>();
+    private Set<RSPos> blocksDirtyNew = new HashSet<RSPos>();
+    private Set<RSPos> blocksDirtyOld = new HashSet<RSPos>();
 
     /**
      * Create a new RS manager for a world.
@@ -95,10 +100,87 @@ public class RSManager {
      * @param x
      * @param y
      * @param z
-     * @param charged Whether this block is charged or not
+     * @param charge The charge level to set this block to.
+     * @param oneTick Flag to indicate if we must discharge this block in the next tick.
      */
-    private void setBlockCharge(int x, int y, int z, boolean charged) {
-        // TODO!
+    public void setBlockCharge(int x, int y, int z, int charge, boolean oneTick) {
+        assert(charge >= 0 && charge <= 15);
+        RSPos p = new RSPos(x, y, z);
+        redChargeNew.put(p, (Integer)((charge&15) | (oneTick?0x20:0x00)));
+    }
+
+    /**
+     * Sets the charge of a given block.
+     * @param block The block to set the charge of.
+     * @param charge The charge level to set this block to.
+     * @param oneTick Flag to indicate if we must discharge this block in the next tick.
+     */
+    public void setBlockCharge(Block block, int charge, boolean oneTick) {
+        setBlockCharge(block.getX(), block.getY(), block.getZ(), charge, oneTick);
+    }
+
+    /**
+     * Sets the charge of a given block.
+     * @param p The position of the block to set the charge of.
+     * @param charge The charge level to set this block to.
+     * @param oneTick Flag to indicate if we must discharge this block in the next tick.
+     */
+    public void setBlockCharge(RSPos p, int charge, boolean oneTick) {
+        setBlockCharge(p.x, p.y, p.z, charge, oneTick);
+    }
+
+    /**
+     * Trace from a block to another block.
+     * @param srcBlock The block we are sourcing from.
+     * @param flowDir The direction of redstone flow from this block.
+     * @param inPower The input power level.
+     * @param isDirect Whether we are applying direct or indirect power.
+     */
+    public void traceFromBlock(GlowBlock srcBlock, BlockFace flowDir, int inPower, boolean isDirect) {
+        // Get source material
+        Material srcMat = srcBlock.getType();
+
+        // Get destination block
+        GlowBlock destBlock = srcBlock.getRelative(flowDir);
+        if(destBlock == null) {
+            return;
+        }
+        Material destMat = destBlock.getType();
+        BlockType destType = ItemTable.instance().getBlock(destMat);
+        if(destType == null) {
+            return;
+        }
+
+        // Perform trace routine
+        if(DEBUG_REDSTONE) {
+            System.out.println(String.format("trace to %s", destBlock));
+        }
+        destType.traceBlockPower(destBlock, this, srcMat, flowDir, inPower, isDirect);
+    }
+
+    /**
+     * Trace from a block, provided there is no power coming from the given direction.
+     * @param srcBlock The block we are sourcing from.
+     * @param flowDir The direction of redstone flow from this block.
+     * @param inPower The input power level.
+     * @param isDirect Whether we are applying direct or indirect power.
+     */
+    public void traceFromBlockIfUnpowered(GlowBlock srcBlock, BlockFace flowDir, int inPower, boolean isDirect) {
+        // TODO: Check if destination is powered.
+        // Perform trace.
+        traceFromBlock(srcBlock, flowDir, inPower, isDirect);
+    }
+
+    /**
+     * Adds a source for tracing updates.
+     * @param block The block we use as a source.
+     */
+    public void addSource(Block block) {
+        RSPos p = new RSPos(block);
+        redSourceNew.add(p);
+        if(DEBUG_REDSTONE) {
+            System.out.println(String.format("adding source %s", block));
+        }
     }
 
     /**
@@ -110,7 +192,9 @@ public class RSManager {
         // TODO: Check if we need to prevent double-removals of a chunk
         RSPos cp = new RSPos(chunkX, 0, chunkZ);
 
-        //System.out.println(String.format("red chunk !DROP! %d %d", chunkX, chunkZ));
+        if(DEBUG_REDSTONE) {
+            System.out.println(String.format("red chunk !DROP! %d %d", chunkX, chunkZ));
+        }
 
         // Loop
         for(int y = 0; y < 256; y++)
@@ -123,10 +207,19 @@ public class RSManager {
             RSPos p = new RSPos(rx, ry, rz);
 
             // Remove this from all appropriate sets
-            redTorches.remove(p);
-            redSources.remove(p);
-            redSinks.remove(p);
+            redChargeNew.remove(p);
+            redSourceNew.remove(p);
         }
+    }
+
+    /**
+     * Marks a block as dirty so the redstone manager can update it.
+     * @param x
+     * @param y
+     * @param z
+     */
+    public synchronized void dirtyRedBlock(int x, int y, int z) {
+        blocksDirtyNew.add(new RSPos(x, y, z));
     }
 
     /**
@@ -135,7 +228,31 @@ public class RSManager {
      * @param chunkZ
      */
     public synchronized void dirtyRedChunk(int chunkX, int chunkZ) {
-        chunksDirty.add(new RSPos(chunkX, 0, chunkZ));
+        chunksDirtyNew.add(new RSPos(chunkX, 0, chunkZ));
+    }
+
+    /**
+     * Updates the redstone state for a block.
+     * @param x
+     * @param y
+     * @param z
+     */
+    private synchronized void updateRedBlock(int x, int y, int z) {
+        if(DEBUG_REDSTONE) {
+            System.out.println(String.format("red block update %d %d %d", x, y, z));
+        }
+
+        // Get block
+        GlowBlock block = world.getBlockAt(x, y, z);
+        if(block == null) {
+            return;
+        }
+        BlockType type = ItemTable.instance().getBlock(block.getType());
+
+        // Check if we can add this as a source
+        if(type != null && type.isRedSource(block)) {
+            addSource(block);
+        }
     }
 
     /**
@@ -144,49 +261,27 @@ public class RSManager {
      * @param chunkZ
      */
     private synchronized void updateRedChunk(int chunkX, int chunkZ) {
-        //System.out.println(String.format("red chunk update %d %d", chunkX, chunkZ));
-        RSPos cp = new RSPos(chunkX, 0, chunkZ);
+        if(DEBUG_REDSTONE) {
+            //System.out.println(String.format("red chunk update %d %d", chunkX, chunkZ));
+        }
 
-        // Fetch IDs and metadata
+        // Fetch chunk
+        GlowChunk chunk = world.getChunkAt(chunkX, chunkZ);
+
         // Loop
         for(int pos = 0, y = 0; y < 256; y++)
         for(int z = 0; z < 16; z++)
         for(int x = 0; x < 16; x++, pos++) {
-            // Get type from chunk
-            // TODO: Source from world
-            RSBlock type = RSBlock.B_AIR;
-            int meta = 0x00;
-            boolean charged = false;
+            // Get block
+            GlowBlock block = chunk.getBlock(x, y, z);
+            if(block == null) {
+                continue;
+            }
+            BlockType type = ItemTable.instance().getBlock(block.getType());
 
-            // Get position
-            int rx = x + (chunkX << 4);
-            int ry = y;
-            int rz = z + (chunkZ << 4);
-            RSPos p = new RSPos(rx, ry, rz);
-
-            // Remove this from all appropriate sets
-            redTorches.remove(p);
-            redSources.remove(p);
-            redSinks.remove(p);
-
-            switch(type) {
-                case B_AIR:
-                    // Air is never a source
-                    break;
-                case B_RWIRE:
-                    // Wire isn't actually used at this step
-                    break;
-                case B_RTORCH:
-                    // Add this to the torches AND charges AND sources
-                    p = new RSPos(rx, ry, rz);
-                    redTorches.add(p);
-                    if(!charged) redSources.add(p);
-                    break;
-                case B_SOLID:
-                    // Add this to the charges AND sources
-                    p = new RSPos(rx, ry, rz);
-                    if(charged) redSources.add(p);
-                    break;
+            // Check if we can add this as a source
+            if(type != null && type.isRedSource(block)) {
+                addSource(block);
             }
         }
     }
@@ -202,62 +297,127 @@ public class RSManager {
      * Update all the redstone logic in the manager's assigned world.
      */
     public synchronized void pulse() {
+        if(DEBUG_REDSTONE) {
+            //System.out.println("RSManager pulse() start");
+        }
+
         // Swap chunksDirty buffers
-        Set<RSPos> cdtemp = chunksDirty;
-        chunksDirty = chunksDirtyBack;
-        chunksDirtyBack = cdtemp;
+        Set<RSPos> chunksDirtyTemp = chunksDirtyNew;
+        chunksDirtyNew = chunksDirtyOld;
+        chunksDirtyOld = chunksDirtyTemp;
 
         // Clear dirty chunks
-        chunksDirty.clear();
+        chunksDirtyNew.clear();
 
         // Update all dirty chunks
-        for(RSPos p : chunksDirtyBack) {
+        for(RSPos p : chunksDirtyOld) {
             // Skip unloaded chunks
-            if(!isChunkLoaded(p.x, p.z)) continue;
+            if(!isChunkLoaded(p.x, p.z)) {
+                continue;
+            }
 
             // Update RS chunk
             updateRedChunk(p.x, p.z);
         }
 
-        // Clear sinks
-        redSinks.clear();
+        // Swap blocksDirty buffers
+        Set<RSPos> blocksDirtyTemp = blocksDirtyNew;
+        blocksDirtyNew = blocksDirtyOld;
+        blocksDirtyOld = blocksDirtyTemp;
 
-        // Discharge wires
-        for(RSPos p : redChargedWires)
-            setBlockCharge(p.x, p.y, p.z, false);
+        // Clear dirty blocks
+        blocksDirtyNew.clear();
 
-        redChargedWires.clear();
+        // Update all dirty blocks
+        for(RSPos p : blocksDirtyOld) {
+            // Skip unloaded chunks
+            if(!isChunkLoaded(p.x>>4, p.z>>4)) {
+                continue;
+            }
 
-        // Lead sources to sinks
-        // TODO: Integrate properly
-        /*
-        for(RSPos p : redSources)
-            traceRedStart(p.x, p.y, p.z);
-        */
-
-        // Discharge sources
-        for(RSPos p : redSources)
-            setBlockCharge(p.x, p.y, p.z, false);
-
-        // Charge sinks
-        for(RSPos p : redSinks)
-            setBlockCharge(p.x, p.y, p.z, true);
-
-        // Charge wires
-        for(RSPos p : redChargedWires)
-            setBlockCharge(p.x, p.y, p.z, true);
-
-        // Flip sinks for torches
-        for(RSPos p : redTorches) {
-            if(redSinks.contains(p))
-                redSinks.remove(p);
-            else
-                redSinks.add(p);
+            // Update RS block
+            updateRedBlock(p.x, p.y, p.z);
         }
 
-        // Swap RS sources and sinks
-        Set<RSPos> rstemp = redSources;
-        redSources = redSinks;
-        redSinks = rstemp;
+        // Swap sources and clear new
+        Set<RSPos> redSourceTemp = redSourceNew;
+        redSourceNew = redSourceOld;
+        redSourceOld = redSourceTemp;
+        redSourceNew.clear();
+
+        // Swap charges and clear new
+        Map<RSPos,Integer> redChargeTemp = redChargeNew;
+        redChargeNew = redChargeOld;
+        redChargeOld = redChargeTemp;
+        redChargeNew.clear();
+
+        // Initialise sources
+        for(RSPos p : redSourceOld) {
+            GlowBlock block = world.getBlockAt(p.x, p.y, p.z);
+            if(block == null) {
+                continue;
+            }
+            BlockType type = ItemTable.instance().getBlock(block.getType());
+            if(type == null) {
+                continue;
+            }
+            type.traceBlockPowerInit(block, this);
+        }
+
+        // Trace from sources
+        for(RSPos p : redSourceOld) {
+            GlowBlock block = world.getBlockAt(p.x, p.y, p.z);
+            if(block == null) {
+                continue;
+            }
+            BlockType type = ItemTable.instance().getBlock(block.getType());
+            if(type == null) {
+                continue;
+            }
+            type.traceBlockPowerStart(block, this);
+        }
+
+        // Handle old wire charges
+        for(RSPos p : redChargeOld.keySet()) {
+            if(!redChargeNew.containsKey(p)) {
+                GlowBlock block = world.getBlockAt(p.x, p.y, p.z);
+                if(block == null) {
+                    continue;
+                }
+
+                int charge = redChargeOld.get(p);
+                boolean oneTick = ((charge & 0x20) != 0);
+                charge &= 0x0F;
+                BlockType type = ItemTable.instance().getBlock(block.getType());
+                if(type == null) {
+                    continue;
+                }
+
+                // Determine whether we discharge now or let it be
+                if(oneTick) {
+                    if(charge > 0) {
+                        type.traceBlockPowerEnd(block, this, 0);
+                    }
+                } else {
+                    redChargeNew.put(p, charge);
+                }
+            }
+        }
+
+        // Charge new wires
+        for(RSPos p : redChargeNew.keySet()) {
+            GlowBlock block = world.getBlockAt(p.x, p.y, p.z);
+            if(block == null) {
+                continue;
+            }
+
+            int charge = redChargeNew.get(p);
+            BlockType type = ItemTable.instance().getBlock(block.getType());
+            if(type == null) {
+                continue;
+            }
+
+            type.traceBlockPowerEnd(block, this, charge & 0x0F);
+        }
     }
 }

--- a/src/main/java/net/glowstone/RSManager.java
+++ b/src/main/java/net/glowstone/RSManager.java
@@ -8,36 +8,34 @@ import java.util.*;
  * A class to manage redstone logic for a world.
  * @author Ben Russell
  */
-public class RSManager
-{
+public class RSManager {
     /**
-     * A manual enumeration of block types.
-     * TODO: Something better, perhaps?
+     * An enum of block types.
      */
-    public final int B_AIR = 0;
-    public final int B_SOLID = 1;
-    public final int B_RWIRE = 2;
-    public final int B_RTORCH = 3;
-    public final int B_RDIODE = 4; // Not supported yet
+    // TODO: Change this to use BlockType instead
+    public enum RSBlock {
+        B_AIR,
+        B_SOLID,
+        B_RWIRE,
+        B_RTORCH,
+        B_RDIODE, // Not supported yet
+    }
 
     /**
      * An immutable class for storing 3D world positions.
      * TODO: Consider using Location (assuming it's hashable to the nearest int^3)
      */
-    public final class RSPos
-    {
+    public final class RSPos {
         public final int x, y, z;
 
-        public RSPos(int x, int y, int z)
-        {
+        public RSPos(int x, int y, int z) {
             this.x = x;
             this.y = y;
             this.z = z;
         }
 
         @Override
-        public int hashCode()
-        {
+        public int hashCode() {
             int hash = 1;
 
             hash = hash * 31 + this.y;
@@ -48,10 +46,8 @@ public class RSManager
         }
 
         @Override
-        public boolean equals(Object o)
-        {
-            if(o instanceof RSPos)
-            {
+        public boolean equals(Object o) {
+            if(o instanceof RSPos) {
                 RSPos op = (RSPos)o;
 
                 return true
@@ -65,8 +61,7 @@ public class RSManager
         }
 
         @Override
-        public String toString()
-        {
+        public String toString() {
             return String.format("RSPos(%d, %d, %d)", x, y, z);
         }
     }
@@ -79,21 +74,18 @@ public class RSManager
     /**
      * Various redstone-related sets, maps and lists.
      */ 
-    private HashSet<RSPos> redTorches = new HashSet<RSPos>();
-    private HashSet<RSPos> redSources = new HashSet<RSPos>();
-    private ArrayList<RSPos> redChargedWires = new ArrayList<RSPos>();
-    private HashSet<RSPos> redSinks = new HashSet<RSPos>();
-    private HashMap<RSPos, byte[]> redTypes = new HashMap<RSPos, byte[]>();
-    private HashMap<RSPos, byte[]> redMeta = new HashMap<RSPos, byte[]>();
-    private HashSet<RSPos> chunksDirty = new HashSet<RSPos>();
-    private HashSet<RSPos> chunksDirtyBack = new HashSet<RSPos>();
+    private Set<RSPos> redTorches = new HashSet<RSPos>();
+    private Set<RSPos> redSources = new HashSet<RSPos>();
+    private List<RSPos> redChargedWires = new ArrayList<RSPos>();
+    private Set<RSPos> redSinks = new HashSet<RSPos>();
+    private Set<RSPos> chunksDirty = new HashSet<RSPos>();
+    private Set<RSPos> chunksDirtyBack = new HashSet<RSPos>();
 
     /**
      * Create a new RS manager for a world.
      * @param world The world this manager pertains to
      */
-    public RSManager(GlowWorld world)
-    {
+    public RSManager(GlowWorld world) {
         this.world = world;
         // TODO: Get a list of chunks and mark the loaded ones as dirty
     }
@@ -105,8 +97,7 @@ public class RSManager
      * @param z
      * @param charged Whether this block is charged or not
      */
-    private void setBlockCharge(int x, int y, int z, boolean charged)
-    {
+    private void setBlockCharge(int x, int y, int z, boolean charged) {
         // TODO!
     }
 
@@ -115,22 +106,16 @@ public class RSManager
      * @param chunkX
      * @param chunkZ
      */
-    public synchronized void dropRedChunk(int chunkX, int chunkZ)
-    {
+    public synchronized void dropRedChunk(int chunkX, int chunkZ) {
         // TODO: Check if we need to prevent double-removals of a chunk
         RSPos cp = new RSPos(chunkX, 0, chunkZ);
-
-        // Delete redTypes/redMeta
-        redTypes.remove(cp);
-        redMeta .remove(cp);
 
         //System.out.println(String.format("red chunk !DROP! %d %d", chunkX, chunkZ));
 
         // Loop
         for(int y = 0; y < 256; y++)
         for(int z = 0; z < 16; z++)
-        for(int x = 0; x < 16; x++)
-        {
+        for(int x = 0; x < 16; x++) {
             // Get position
             int rx = x + (chunkX << 4);
             int ry = y;
@@ -149,8 +134,7 @@ public class RSManager
      * @param chunkX
      * @param chunkZ
      */
-    public synchronized void dirtyRedChunk(int chunkX, int chunkZ)
-    {
+    public synchronized void dirtyRedChunk(int chunkX, int chunkZ) {
         chunksDirty.add(new RSPos(chunkX, 0, chunkZ));
     }
 
@@ -159,28 +143,20 @@ public class RSManager
      * @param chunkX
      * @param chunkZ
      */
-    private synchronized void updateRedChunk(int chunkX, int chunkZ)
-    {
+    private synchronized void updateRedChunk(int chunkX, int chunkZ) {
         //System.out.println(String.format("red chunk update %d %d", chunkX, chunkZ));
         RSPos cp = new RSPos(chunkX, 0, chunkZ);
 
         // Fetch IDs and metadata
-        byte[] blockIDs  = (redTypes.containsKey(cp) ? redTypes.get(cp) : new byte[16*16*256]);
-        byte[] blockMeta = (redMeta .containsKey(cp) ? redMeta .get(cp) : new byte[16*16*256]);
-
         // Loop
         for(int pos = 0, y = 0; y < 256; y++)
         for(int z = 0; z < 16; z++)
-        for(int x = 0; x < 16; x++, pos++)
-        {
-            // Get type from chunk (TODO!)
-            int type = B_AIR;
+        for(int x = 0; x < 16; x++, pos++) {
+            // Get type from chunk
+            // TODO: Source from world
+            RSBlock type = B_AIR;
             int meta = 0x00;
             boolean charged = false;
-
-            // Write type
-            blockIDs[pos]  = (byte)type;
-            blockMeta[pos] = (byte)meta;
 
             // Get position
             int rx = x + (chunkX << 4);
@@ -193,50 +169,39 @@ public class RSManager
             redSources.remove(p);
             redSinks.remove(p);
 
-            switch(type)
-            {
+            switch(type) {
                 case B_AIR:
                     // Air is never a source
                     break;
-
                 case B_RWIRE:
                     // Wire isn't actually used at this step
                     break;
-
                 case B_RTORCH:
                     // Add this to the torches AND charges AND sources
                     p = new RSPos(rx, ry, rz);
                     redTorches.add(p);
                     if(!charged) redSources.add(p);
                     break;
-
                 case B_SOLID:
                     // Add this to the charges AND sources
                     p = new RSPos(rx, ry, rz);
                     if(charged) redSources.add(p);
                     break;
-
             }
         }
-
-        // Update redTypes and redMeta
-        redTypes.put(cp, blockIDs );
-        redMeta .put(cp, blockMeta);
     }
 
     /**
      * Determine if a given chunk is loaded or not.
      */
-    private boolean isChunkLoaded(int x, int z)
-    {
+    private boolean isChunkLoaded(int x, int z) {
         return world.isChunkLoaded(x, z);
     }
 
     /**
      * Update all the redstone logic in the manager's assigned world.
      */
-    public synchronized void pulse()
-    {
+    public synchronized void pulse() {
         // Swap chunksDirty buffers
         HashSet<RSPos> cdtemp = chunksDirty;
         chunksDirty = chunksDirtyBack;
@@ -246,8 +211,7 @@ public class RSManager
         chunksDirty.clear();
 
         // Update all dirty chunks
-        for(RSPos p : chunksDirtyBack)
-        {
+        for(RSPos p : chunksDirtyBack) {
             // Skip unloaded chunks
             if(!isChunkLoaded(p.x, p.z)) continue;
 
@@ -284,8 +248,7 @@ public class RSManager
             setBlockCharge(p.x, p.y, p.z, true);
 
         // Flip sinks for torches
-        for(RSPos p : redTorches)
-        {
+        for(RSPos p : redTorches) {
             if(redSinks.contains(p))
                 redSinks.remove(p);
             else
@@ -298,4 +261,3 @@ public class RSManager
         redSinks = rstemp;
     }
 }
-

--- a/src/main/java/net/glowstone/RSManager.java
+++ b/src/main/java/net/glowstone/RSManager.java
@@ -154,7 +154,7 @@ public class RSManager {
         for(int x = 0; x < 16; x++, pos++) {
             // Get type from chunk
             // TODO: Source from world
-            RSBlock type = B_AIR;
+            RSBlock type = RSBlock.B_AIR;
             int meta = 0x00;
             boolean charged = false;
 
@@ -203,7 +203,7 @@ public class RSManager {
      */
     public synchronized void pulse() {
         // Swap chunksDirty buffers
-        HashSet<RSPos> cdtemp = chunksDirty;
+        Set<RSPos> cdtemp = chunksDirty;
         chunksDirty = chunksDirtyBack;
         chunksDirtyBack = cdtemp;
 
@@ -256,7 +256,7 @@ public class RSManager {
         }
 
         // Swap RS sources and sinks
-        HashSet<RSPos> rstemp = redSources;
+        Set<RSPos> rstemp = redSources;
         redSources = redSinks;
         redSinks = rstemp;
     }

--- a/src/main/java/net/glowstone/RSManager.java
+++ b/src/main/java/net/glowstone/RSManager.java
@@ -249,8 +249,6 @@ public class RSManager {
      * @param chunkZ
      */
     public synchronized void dropChunk(int chunkX, int chunkZ) {
-        // We could prevent double-removals of a chunk,
-        //
         RSPos cp = new RSPos(chunkX, 0, chunkZ);
 
         if(DEBUG_REDSTONE) {

--- a/src/main/java/net/glowstone/RSManager.java
+++ b/src/main/java/net/glowstone/RSManager.java
@@ -177,21 +177,18 @@ public class RSManager {
 
 
     /**
-     * Trace from a block to another block.
+     * Trace to a block from another block.
      * @param srcBlock The block we are sourcing from.
-     * @param flowDir The direction of redstone flow from this block.
+     * @param destBlock The block we are targeting.
+     * @param flowDir The direction of redstone flow from the source block.
      * @param inPower The input power level.
      * @param isDirect Whether we are applying direct or indirect power.
      */
-    public void traceFromBlock(GlowBlock srcBlock, BlockFace flowDir, int inPower, boolean isDirect) {
+    public void traceFromBlockToBlock(GlowBlock srcBlock, GlowBlock destBlock, BlockFace flowDir, int inPower, boolean isDirect) {
         // Get source material
         Material srcMat = srcBlock.getType();
 
-        // Get destination block
-        GlowBlock destBlock = srcBlock.getRelative(flowDir);
-        if(destBlock == null) {
-            return;
-        }
+        // Get destination block data
         Material destMat = destBlock.getType();
         BlockType destType = ItemTable.instance().getBlock(destMat);
         if(destType == null) {
@@ -203,6 +200,24 @@ public class RSManager {
             System.out.println(String.format("trace to %s", destBlock));
         }
         destType.traceBlockPower(destBlock, this, srcMat, flowDir, inPower, isDirect);
+    }
+
+    /**
+     * Trace from a block to another block.
+     * @param srcBlock The block we are sourcing from.
+     * @param flowDir The direction of redstone flow from this block.
+     * @param inPower The input power level.
+     * @param isDirect Whether we are applying direct or indirect power.
+     */
+    public void traceFromBlock(GlowBlock srcBlock, BlockFace flowDir, int inPower, boolean isDirect) {
+        // Get destination block
+        GlowBlock destBlock = srcBlock.getRelative(flowDir);
+        if(destBlock == null) {
+            return;
+        }
+
+        // Move to block
+        traceFromBlockToBlock(srcBlock, destBlock, flowDir, inPower, isDirect);
     }
 
     /**

--- a/src/main/java/net/glowstone/block/GlowBlock.java
+++ b/src/main/java/net/glowstone/block/GlowBlock.java
@@ -168,8 +168,7 @@ public final class GlowBlock implements Block {
 
     @Override
     public Material getType() {
-        Material mat = Material.getMaterial(getTypeId());
-        return (mat == null ? Material.AIR : mat);
+        return Material.getMaterial(getTypeId());
     }
 
     @Override
@@ -277,7 +276,7 @@ public final class GlowBlock implements Block {
         if(type == null) {
             return false;
         }
-        return type.isBlockEmittingPower(this, face, true) &&
+        return type.canBlockEmitPower(this, face, true) &&
             getWorld().getRSManager().getBlockPower(this) > 0;
     }
 
@@ -287,7 +286,7 @@ public final class GlowBlock implements Block {
         if(type == null) {
             return false;
         }
-        return type.isBlockEmittingPower(this, face, false) &&
+        return type.canBlockEmitPower(this, face, false) &&
             getWorld().getRSManager().getBlockPower(this) > 0;
     }
 
@@ -297,7 +296,7 @@ public final class GlowBlock implements Block {
         if(type == null) {
             return 0;
         }
-        return (type.isBlockEmittingPower(this, face, false) 
+        return (type.canBlockEmitPower(this, face, false) 
             ? getWorld().getRSManager().getBlockPower(this)
             : 0);
     }

--- a/src/main/java/net/glowstone/block/GlowBlock.java
+++ b/src/main/java/net/glowstone/block/GlowBlock.java
@@ -2,6 +2,7 @@ package net.glowstone.block;
 
 import net.glowstone.GlowChunk;
 import net.glowstone.GlowWorld;
+import net.glowstone.block.blocktype.BlockType;
 import net.glowstone.block.entity.TileEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.message.play.game.BlockChangeMessage;
@@ -261,32 +262,44 @@ public final class GlowBlock implements Block {
 
     @Override
     public boolean isBlockPowered() {
-        return false;
+        return isBlockFacePowered(BlockFace.SELF);
     }
 
     @Override
     public boolean isBlockIndirectlyPowered() {
-        return false;
+        return isBlockFaceIndirectlyPowered(BlockFace.SELF);
     }
 
     @Override
     public boolean isBlockFacePowered(BlockFace face) {
-        return false;
+        BlockType type = ItemTable.instance().getBlock(getType());
+        if(type == null) {
+            return false;
+        }
+        return type.getBlockPower(this, face, true) > 0;
     }
 
     @Override
     public boolean isBlockFaceIndirectlyPowered(BlockFace face) {
-        return false;
+        BlockType type = ItemTable.instance().getBlock(getType());
+        if(type == null) {
+            return false;
+        }
+        return type.getBlockPower(this, face, false) > 0;
     }
 
     @Override
     public int getBlockPower(BlockFace face) {
-        return 0;
+        BlockType type = ItemTable.instance().getBlock(getType());
+        if(type == null) {
+            return 0;
+        }
+        return type.getBlockPower(this, face, true);
     }
 
     @Override
     public int getBlockPower() {
-        return 0;
+        return getBlockPower(BlockFace.SELF);
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/GlowBlock.java
+++ b/src/main/java/net/glowstone/block/GlowBlock.java
@@ -276,8 +276,7 @@ public final class GlowBlock implements Block {
         if(type == null) {
             return false;
         }
-        return type.canBlockEmitPower(this, face, true) &&
-            getWorld().getRSManager().getBlockPower(this) > 0;
+        return type.canBlockEmitPower(this, face, true) && getWorld().getRSManager().getBlockPower(this) > 0;
     }
 
     @Override
@@ -286,8 +285,7 @@ public final class GlowBlock implements Block {
         if(type == null) {
             return false;
         }
-        return type.canBlockEmitPower(this, face, false) &&
-            getWorld().getRSManager().getBlockPower(this) > 0;
+        return type.canBlockEmitPower(this, face, false) && getWorld().getRSManager().getBlockPower(this) > 0;
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/GlowBlock.java
+++ b/src/main/java/net/glowstone/block/GlowBlock.java
@@ -168,7 +168,8 @@ public final class GlowBlock implements Block {
 
     @Override
     public Material getType() {
-        return Material.getMaterial(getTypeId());
+        Material mat = Material.getMaterial(getTypeId());
+        return (mat == null ? Material.AIR : mat);
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/GlowBlock.java
+++ b/src/main/java/net/glowstone/block/GlowBlock.java
@@ -294,9 +294,7 @@ public final class GlowBlock implements Block {
         if(type == null) {
             return 0;
         }
-        return (type.canBlockEmitPower(this, face, false) 
-            ? getWorld().getRSManager().getBlockPower(this)
-            : 0);
+        return type.canBlockEmitPower(this, face, false) ? getWorld().getRSManager().getBlockPower(this) : 0;
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/GlowBlock.java
+++ b/src/main/java/net/glowstone/block/GlowBlock.java
@@ -276,7 +276,8 @@ public final class GlowBlock implements Block {
         if(type == null) {
             return false;
         }
-        return type.getBlockPower(this, face, true) > 0;
+        return type.isBlockEmittingPower(this, face, true) &&
+            getWorld().getRSManager().getBlockPower(this) > 0;
     }
 
     @Override
@@ -285,7 +286,8 @@ public final class GlowBlock implements Block {
         if(type == null) {
             return false;
         }
-        return type.getBlockPower(this, face, false) > 0;
+        return type.isBlockEmittingPower(this, face, false) &&
+            getWorld().getRSManager().getBlockPower(this) > 0;
     }
 
     @Override
@@ -294,12 +296,14 @@ public final class GlowBlock implements Block {
         if(type == null) {
             return 0;
         }
-        return type.getBlockPower(this, face, true);
+        return (type.isBlockEmittingPower(this, face, false) 
+            ? getWorld().getRSManager().getBlockPower(this)
+            : 0);
     }
 
     @Override
     public int getBlockPower() {
-        return getBlockPower(BlockFace.SELF);
+        return getWorld().getRSManager().getBlockPower(this);
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/GlowBlock.java
+++ b/src/main/java/net/glowstone/block/GlowBlock.java
@@ -261,32 +261,32 @@ public final class GlowBlock implements Block {
 
     @Override
     public boolean isBlockPowered() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return false;
     }
 
     @Override
     public boolean isBlockIndirectlyPowered() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return false;
     }
 
     @Override
     public boolean isBlockFacePowered(BlockFace face) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return false;
     }
 
     @Override
     public boolean isBlockFaceIndirectlyPowered(BlockFace face) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return false;
     }
 
     @Override
     public int getBlockPower(BlockFace face) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return 0;
     }
 
     @Override
     public int getBlockPower() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return 0;
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -114,8 +114,8 @@ public final class ItemTable {
         reg(Material.BED_BLOCK, new BlockBed());
         reg(Material.TORCH, new BlockTorch(Material.TORCH));
         reg(Material.REDSTONE_WIRE, new BlockRedstoneDust());
-        reg(Material.REDSTONE_TORCH_OFF, new BlockTorch(Material.REDSTONE_TORCH_OFF));
-        reg(Material.REDSTONE_TORCH_ON , new BlockTorch(Material.REDSTONE_TORCH_OFF));
+        reg(Material.REDSTONE_TORCH_OFF, new BlockRedstoneTorch(Material.REDSTONE_TORCH_OFF));
+        reg(Material.REDSTONE_TORCH_ON , new BlockRedstoneTorch(Material.REDSTONE_TORCH_OFF));
 
         reg(Material.SIGN, new ItemSign());
         reg(Material.REDSTONE, new ItemPlaceAs(Material.REDSTONE_WIRE));

--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -113,8 +113,9 @@ public final class ItemTable {
         reg(Material.WOOD_BUTTON, new BlockButton(Material.WOOD_BUTTON));
         reg(Material.BED_BLOCK, new BlockBed());
         reg(Material.TORCH, new BlockTorch(Material.TORCH));
-        reg(Material.REDSTONE_TORCH_ON, new BlockTorch(Material.REDSTONE_TORCH_ON));
+        reg(Material.REDSTONE_WIRE, new BlockRedstoneDust());
         reg(Material.REDSTONE_TORCH_OFF, new BlockTorch(Material.REDSTONE_TORCH_ON));
+        reg(Material.REDSTONE_TORCH_ON, new BlockTorch(Material.REDSTONE_TORCH_ON));
 
         reg(Material.SIGN, new ItemSign());
         reg(Material.REDSTONE, new ItemPlaceAs(Material.REDSTONE_WIRE));

--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -112,6 +112,9 @@ public final class ItemTable {
         reg(Material.STONE_BUTTON, new BlockButton(Material.STONE_BUTTON));
         reg(Material.WOOD_BUTTON, new BlockButton(Material.WOOD_BUTTON));
         reg(Material.BED_BLOCK, new BlockBed());
+        reg(Material.TORCH, new BlockTorch(Material.TORCH));
+        reg(Material.REDSTONE_TORCH_ON, new BlockTorch(Material.REDSTONE_TORCH_ON));
+        reg(Material.REDSTONE_TORCH_OFF, new BlockTorch(Material.REDSTONE_TORCH_ON));
 
         reg(Material.SIGN, new ItemSign());
         reg(Material.REDSTONE, new ItemPlaceAs(Material.REDSTONE_WIRE));

--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -114,8 +114,8 @@ public final class ItemTable {
         reg(Material.BED_BLOCK, new BlockBed());
         reg(Material.TORCH, new BlockTorch(Material.TORCH));
         reg(Material.REDSTONE_WIRE, new BlockRedstoneDust());
-        reg(Material.REDSTONE_TORCH_OFF, new BlockTorch(Material.REDSTONE_TORCH_ON));
-        reg(Material.REDSTONE_TORCH_ON, new BlockTorch(Material.REDSTONE_TORCH_ON));
+        reg(Material.REDSTONE_TORCH_OFF, new BlockTorch(Material.REDSTONE_TORCH_OFF));
+        reg(Material.REDSTONE_TORCH_ON , new BlockTorch(Material.REDSTONE_TORCH_OFF));
 
         reg(Material.SIGN, new ItemSign());
         reg(Material.REDSTONE, new ItemPlaceAs(Material.REDSTONE_WIRE));

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
@@ -1,13 +1,76 @@
 package net.glowstone.block.blocktype;
 
+import net.glowstone.RSManager;
 import net.glowstone.block.GlowBlock;
 import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.*;
 
 public class BlockRedstoneDust extends BlockType {
     // TODO: handle properly
+
+    @Override
+    public boolean isBlockEmittingPower(GlowBlock block, BlockFace face, boolean isDirect) {
+        // RS wire does not emit directly
+        if(isDirect) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void traceBlockPowerInit(GlowBlock block, RSManager rsManager) {
+        // XXX: Do we discharge here, or rely on rsManager?
+    }
+
+    @Override
+    public void traceBlockPowerStart(GlowBlock block, RSManager rsManager) {
+        // This does not trace from the "start".
+    }
+
+    private void traceBlockPowerRSWire(GlowBlock block, RSManager rsManager, BlockFace blockDir, BlockFace outDir, int inPower, boolean isDirect) {
+        // TODO!
+    }
+
+    @Override
+    public void traceBlockPower(GlowBlock block, RSManager rsManager, Material srcMat, BlockFace flowDir, int inPower, boolean isDirect) {
+        // Bail out if our input power is <= our current power
+        if(inPower <= rsManager.getNewBlockPower(block)) {
+            return;
+        }
+
+        // Set power
+        rsManager.setBlockPower(block, inPower, true);
+
+        // Check if power sufficient
+        if(inPower <= 1) {
+            return;
+        }
+
+        // Spread out
+        BlockFace blockDir = flowDir.getOppositeFace();
+        int outPower = inPower - 1;
+        traceBlockPowerRSWire(block, rsManager, blockDir, BlockFace.NORTH, outPower, false);
+        traceBlockPowerRSWire(block, rsManager, blockDir, BlockFace.SOUTH, outPower, false);
+        traceBlockPowerRSWire(block, rsManager, blockDir, BlockFace.EAST , outPower, false);
+        traceBlockPowerRSWire(block, rsManager, blockDir, BlockFace.WEST , outPower, false);
+    }
+
+    @Override
+    public void traceBlockPowerEnd(GlowBlock block, RSManager rsManager, int power) {
+        // Set block charge
+        assert(power >= 0 && power <= 15);
+        block.setTypeIdAndData(getMaterial().getId(), (byte)(power & 15), false);
+    }
+
+    @Override
+    public boolean canPlaceAt(GlowBlock block, BlockFace against) {
+        GlowBlock floor = block.getRelative(BlockFace.DOWN);
+        return floor != null && floor.getType().isSolid();
+    }
 
     @Override
     public Collection<ItemStack> getDrops(GlowBlock block) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
@@ -132,7 +132,15 @@ public class BlockRedstoneDust extends BlockType {
 
         // If there is exactly one wire (the one we came from!), "inject"
         if(bsum == 0) {
-            traceBlockPowerInject(block, rsManager, flowDir, outPower);
+            if(flowDir == BlockFace.UP || flowDir == BlockFace.DOWN) {
+                // Special case
+                traceBlockPowerInject(block, rsManager, BlockFace.NORTH, outPower);
+                traceBlockPowerInject(block, rsManager, BlockFace.SOUTH, outPower);
+                traceBlockPowerInject(block, rsManager, BlockFace.WEST, outPower);
+                traceBlockPowerInject(block, rsManager, BlockFace.EAST, outPower);
+            } else {
+                traceBlockPowerInject(block, rsManager, flowDir, outPower);
+            }
         }
 
         // Move to floor

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
@@ -1,0 +1,16 @@
+package net.glowstone.block.blocktype;
+
+import net.glowstone.block.GlowBlock;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.*;
+
+public class BlockRedstoneDust extends BlockType {
+    // TODO: handle properly
+
+    @Override
+    public Collection<ItemStack> getDrops(GlowBlock block) {
+        return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.REDSTONE, 1, (short)0)));
+    }
+} 

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
@@ -135,15 +135,24 @@ public class BlockRedstoneDust extends BlockType {
         if(ne) { bsum++; }
         if(nw) { bsum++; }
 
-        // If there is exactly one wire (the one we came from!), "inject"
-        if(bsum == 0) {
-            if(flowDir == BlockFace.UP || flowDir == BlockFace.DOWN) {
-                // Special case
+        // Flow behaves differently from top and bottom
+        if(flowDir == BlockFace.UP || flowDir == BlockFace.DOWN) {
+            if(bsum == 0) {
+                // If there are no wires, "inject" in a spread
                 traceBlockPowerInject(block, rsManager, BlockFace.NORTH, outPower);
                 traceBlockPowerInject(block, rsManager, BlockFace.SOUTH, outPower);
                 traceBlockPowerInject(block, rsManager, BlockFace.WEST, outPower);
                 traceBlockPowerInject(block, rsManager, BlockFace.EAST, outPower);
-            } else {
+            } else if(bsum == 1) {
+                // If there is exactly one wire, "inject" in the OPPOSITE direction
+                if(ns) traceBlockPowerInject(block, rsManager, BlockFace.NORTH, outPower);
+                if(nn) traceBlockPowerInject(block, rsManager, BlockFace.SOUTH, outPower);
+                if(ne) traceBlockPowerInject(block, rsManager, BlockFace.WEST , outPower);
+                if(nw) traceBlockPowerInject(block, rsManager, BlockFace.EAST , outPower);
+            }
+        } else {
+            // If there is exactly one wire (the one we came from!), "inject"
+            if(bsum == 0) {
                 traceBlockPowerInject(block, rsManager, flowDir, outPower);
             }
         }

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
@@ -41,6 +41,7 @@ public class BlockRedstoneDust extends BlockType {
         }
 
         // Get the relevant blocks + materials
+        GlowBlock blockOn   = block.getRelative(BlockFace.UP);
         GlowBlock blockMid  = block.getRelative(outDir.getModX(), outDir.getModY() + 0, outDir.getModZ());
         GlowBlock blockUp   = block.getRelative(outDir.getModX(), outDir.getModY() + 1, outDir.getModZ());
         GlowBlock blockDown = block.getRelative(outDir.getModX(), outDir.getModY() - 1, outDir.getModZ());
@@ -50,6 +51,7 @@ public class BlockRedstoneDust extends BlockType {
         boolean wireUp   = (blockUp   != null && blockUp  .getType() == Material.REDSTONE_WIRE);
         boolean wireDown = (blockDown != null && blockDown.getType() == Material.REDSTONE_WIRE);
 
+        boolean solidOn   = (blockOn   != null && blockOn  .getType().isSolid());
         boolean solidMid  = (blockMid  != null && blockMid .getType().isSolid());
         boolean solidUp   = (blockUp   != null && blockUp  .getType().isSolid());
         boolean solidDown = (blockDown != null && blockDown.getType().isSolid());
@@ -59,7 +61,7 @@ public class BlockRedstoneDust extends BlockType {
             // Down
             // (Mid is nonsolid so Up cannot be RS dust)
             rsManager.traceFromBlockToBlock(block, blockDown, outDir, inPower, isDirect);
-        } else if(solidMid && wireUp) {
+        } else if(solidMid && wireUp && !solidOn) {
             // Up
             rsManager.traceFromBlockToBlock(block, blockUp  , outDir, inPower, isDirect);
         } else if(wireMid) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
@@ -52,21 +52,26 @@ public class BlockRedstoneDust extends BlockType {
         GlowBlock blockMid  = block.getRelative(outDir.getModX(), outDir.getModY() + 0, outDir.getModZ());
         GlowBlock blockUp   = block.getRelative(outDir.getModX(), outDir.getModY() + 1, outDir.getModZ());
         GlowBlock blockDown = block.getRelative(outDir.getModX(), outDir.getModY() - 1, outDir.getModZ());
+        GlowBlock blockSeat = block.getRelative(BlockFace.DOWN);
 
         // Get some flags
         boolean wireMid  = (blockMid  != null && blockMid .getType() == Material.REDSTONE_WIRE);
         boolean wireUp   = (blockUp   != null && blockUp  .getType() == Material.REDSTONE_WIRE);
         boolean wireDown = (blockDown != null && blockDown.getType() == Material.REDSTONE_WIRE);
 
-        boolean solidOn   = (blockOn   != null && blockOn  .getType().isSolid());
-        boolean solidMid  = (blockMid  != null && blockMid .getType().isSolid());
-        boolean solidUp   = (blockUp   != null && blockUp  .getType().isSolid());
-        boolean solidDown = (blockDown != null && blockDown.getType().isSolid());
+        boolean solidOn   = (blockOn   != null && blockOn  .getType().isOccluding());
+        boolean solidMid  = (blockMid  != null && blockMid .getType().isOccluding());
+        boolean solidUp   = (blockUp   != null && blockUp  .getType().isOccluding());
+        boolean solidDown = (blockDown != null && blockDown.getType().isOccluding());
 
         // Check if glowstone 
         boolean glowOn    = (blockOn   != null && blockOn  .getType() == Material.GLOWSTONE);
         if(glowOn) {
             solidOn = false;
+        }
+        boolean glowSeat  = (blockSeat != null && blockSeat.getType() == Material.GLOWSTONE);
+        if(glowSeat) {
+            wireDown = false;
         }
 
         // Determine which one we use
@@ -157,7 +162,7 @@ public class BlockRedstoneDust extends BlockType {
     @Override
     public boolean canPlaceAt(GlowBlock block, BlockFace against) {
         GlowBlock floor = block.getRelative(BlockFace.DOWN);
-        return floor != null && floor.getType().isSolid();
+        return floor != null && floor.getType().isOccluding();
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
@@ -162,7 +162,16 @@ public class BlockRedstoneDust extends BlockType {
     @Override
     public boolean canPlaceAt(GlowBlock block, BlockFace against) {
         GlowBlock floor = block.getRelative(BlockFace.DOWN);
-        return floor != null && floor.getType().isOccluding();
+        if(floor != null) {
+            Material mat = floor.getType();
+            if(mat.isOccluding()) {
+                return true;
+            }
+            if(mat == Material.GLOWSTONE) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneDust.java
@@ -50,19 +50,25 @@ public class BlockRedstoneDust extends BlockType {
         GlowBlock blockFwDn = block.getRelative(outDir.getModX(), outDir.getModY() - 1, outDir.getModZ());
         GlowBlock blockDn   = block.getRelative(BlockFace.DOWN);
 
-        // Get some flags
-        boolean wireMid  = (blockMid  != null && blockMid .getType() == Material.REDSTONE_WIRE);
-        boolean wireFwUp = (blockFwUp != null && blockFwUp.getType() == Material.REDSTONE_WIRE);
-        boolean wireFwDn = (blockFwDn != null && blockFwDn.getType() == Material.REDSTONE_WIRE);
+        Material matUp   = (blockUp   != null ? blockUp  .getType() : null);
+        Material matMid  = (blockMid  != null ? blockMid .getType() : null);
+        Material matFwUp = (blockFwUp != null ? blockFwUp.getType() : null);
+        Material matFwDn = (blockFwDn != null ? blockFwDn.getType() : null);
+        Material matDn   = (blockDn   != null ? blockDn  .getType() : null);
 
-        boolean solidUp   = (blockUp   != null && blockUp  .getType().isOccluding());
-        boolean solidMid  = (blockMid  != null && blockMid .getType().isOccluding());
-        boolean solidFwUp = (blockFwUp != null && blockFwUp.getType().isOccluding());
-        boolean solidFwDn = (blockFwDn != null && blockFwDn.getType().isOccluding());
+        // Get some flags
+        boolean wireMid  = (matMid  == Material.REDSTONE_WIRE);
+        boolean wireFwUp = (matFwUp == Material.REDSTONE_WIRE);
+        boolean wireFwDn = (matFwDn == Material.REDSTONE_WIRE);
+
+        boolean solidUp   = (matUp   != null && matUp  .isOccluding());
+        boolean solidMid  = (matMid  != null && matMid .isOccluding());
+        boolean solidFwUp = (matFwUp != null && matFwUp.isOccluding());
+        boolean solidFwDn = (matFwDn != null && matFwDn.isOccluding());
 
         // Check if glowstone 
-        boolean glowUp    = (blockUp   != null && blockUp  .getType() == Material.GLOWSTONE);
-        boolean glowDn    = (blockDn   != null && blockDn  .getType() == Material.GLOWSTONE);
+        boolean glowUp    = (matUp   == Material.GLOWSTONE);
+        boolean glowDn    = (matDn   == Material.GLOWSTONE);
         if(glowUp) {
             solidFwUp = false;
         }
@@ -84,7 +90,8 @@ public class BlockRedstoneDust extends BlockType {
             if(glowUp) {
                 // Is there a wire 2 steps above us?
                 GlowBlock blockUp2 = blockUp.getRelative(BlockFace.UP);
-                boolean wireUp2 = (blockUp2 != null && blockUp2.getType() == Material.REDSTONE_WIRE);
+                Material matUp2 = (blockUp2 != null ? blockUp2.getType() : null);
+                boolean wireUp2 = (matUp2 == Material.REDSTONE_WIRE);
                 if(wireUp2) {
                     // Yes - trace from FwUp pointing in the direction of that wire.
                     traceBlockPowerRSWire(blockFwUp, rsManager, BlockFace.SELF, outDir.getOppositeFace(), outPower-1, isDirect);

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneTorch.java
@@ -1,0 +1,117 @@
+package net.glowstone.block.blocktype;
+
+import net.glowstone.RSManager;
+import net.glowstone.block.GlowBlock;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+
+import java.util.*;
+
+public class BlockRedstoneTorch extends BlockTorch {
+
+    public BlockRedstoneTorch(Material matType) {
+        super(matType);
+    }
+
+    @Override
+    public boolean canBlockEmitPower(GlowBlock block, BlockFace face, boolean isDirect) {
+        // Torches do not emit behind themselves
+        if (face == getOwnFacing(block).getOppositeFace()) {
+            return false;
+        }
+
+        // Direct emissions ONLY go up
+        if (face != BlockFace.UP && !isDirect) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean isRedSource(GlowBlock block) {
+        return true;
+    }
+
+    @Override
+    public void traceBlockPowerEnd(GlowBlock block, RSManager rsManager, int power) {
+        // Handle power change.
+        Material mat = getMaterial();
+        if(mat == Material.REDSTONE_TORCH_ON && power == 0) {
+            mat = Material.REDSTONE_TORCH_OFF;
+            block.setTypeIdAndData(mat.getId(), (byte)block.getData(), false);
+        } else if(mat == Material.REDSTONE_TORCH_OFF && power != 0) {
+            mat = Material.REDSTONE_TORCH_ON;
+            block.setTypeIdAndData(mat.getId(), (byte)block.getData(), false);
+        }
+
+        rsManager.addSource(block);
+    }
+
+    /**
+     * Trace a redstone pulse from an RS torch outwards.
+     * NOTE: This function can be extended to cater for inPower and isDirect, need-permitting.
+     * @param srcBlock The block we are flowing from.
+     * @param rsManager The RSManager used for tracking.
+     * @param forbidDir The direction we cannot flow in due to it leading back to our source.
+     * @param toDir The direction of redstone flow from this block.
+     * @param isDirect Whether the flow is direct or not.
+     */
+    private void traceBlockPowerFromRSTorch(GlowBlock srcBlock, RSManager rsManager, BlockFace forbidDir, BlockFace toDir, boolean isDirect) {
+        // Get the forbidDir check out of the way.
+        if(forbidDir == toDir) {
+            return;
+        }
+
+        // Trace outwards.
+        rsManager.traceFromBlock(srcBlock, toDir, 15, isDirect);
+    }
+
+    @Override
+    public void traceBlockPowerInit(GlowBlock block, RSManager rsManager) {
+        Material thisMat = getMaterial();
+        if(thisMat == Material.REDSTONE_TORCH_ON) {
+            // Set the charge to ensure that this is handled next tick.
+            rsManager.setBlockPower(block, 15, false);
+        } else if(thisMat == Material.REDSTONE_TORCH_OFF) {
+            // Set the charge now.
+            // If it needs to stay discharged, it will be discharged by other blocks.
+            rsManager.setBlockPower(block, 15, false);
+        }
+    }
+
+    @Override
+    public void traceBlockPowerStart(GlowBlock block, RSManager rsManager) {
+        // Abandon ship if this is not a charged RS torch.
+        Material thisMat = getMaterial();
+        if(thisMat != Material.REDSTONE_TORCH_ON) {
+            return;
+        }
+
+        // Trace in all directions except self.
+        BlockFace selfDir = getOwnFacing(block).getOppositeFace();
+        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.UP, true);
+        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.DOWN, false);
+        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.NORTH, false);
+        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.SOUTH, false);
+        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.WEST, false);
+        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.EAST, false);
+    }
+
+    @Override
+    public void traceBlockPower(GlowBlock block, RSManager rsManager, Material srcMat, BlockFace flowDir, int inPower, boolean isDirect) {
+        // Abandon ship if this is just a regular torch.
+        Material thisMat = getMaterial();
+        if(thisMat != Material.REDSTONE_TORCH_ON && thisMat != Material.REDSTONE_TORCH_OFF) {
+            return;
+        }
+        // Determine if we are getting this from a source.
+        boolean isSource = (getOwnFacing(block) == flowDir);
+        if(isSource) {
+            // Discharge this torch.
+            rsManager.setBlockPower(block, 0, false);
+        } else {
+            // Disregard this.
+        }
+    }
+} 

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneTorch.java
@@ -10,7 +10,7 @@ import java.util.*;
 public class BlockRedstoneTorch extends BlockTorch {
 
     public BlockRedstoneTorch(Material matType) {
-        super(matType);
+        super(matType, Material.REDSTONE_TORCH_OFF);
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
@@ -1,6 +1,5 @@
 package net.glowstone.block.blocktype;
 
-import net.glowstone.RSManager;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.entity.GlowPlayer;
@@ -12,13 +11,14 @@ import org.bukkit.util.Vector;
 import java.util.*;
 
 public class BlockTorch extends BlockType {
+
     private final Material matType;
 
     public BlockTorch(Material matType) {
         this.matType = matType;
     }
 
-    private BlockFace getOwnFacing(GlowBlock block) {
+    protected BlockFace getOwnFacing(GlowBlock block) {
         switch(block.getData()) {
             case 1:
                 return BlockFace.EAST;
@@ -33,7 +33,7 @@ public class BlockTorch extends BlockType {
         }
     }
 
-    private int getFacing(BlockFace face) {
+    protected int getFacing(BlockFace face) {
         switch (face) {
             case EAST:
                 return 1;
@@ -46,109 +46,6 @@ public class BlockTorch extends BlockType {
         }
 
         return 5;
-    }
-
-    @Override
-    public boolean canBlockEmitPower(GlowBlock block, BlockFace face, boolean isDirect) {
-        // Torches do not emit behind themselves
-        if (face == getOwnFacing(block).getOppositeFace()) {
-            return false;
-        }
-
-        // Direct emissions ONLY go up
-        if (face != BlockFace.UP && !isDirect) {
-            return false;
-        }
-
-        return true;
-    }
-
-    @Override
-    public boolean isRedSource(GlowBlock block) {
-        Material thisMat = getMaterial();
-        return thisMat == Material.REDSTONE_TORCH_ON || thisMat == Material.REDSTONE_TORCH_OFF;
-    }
-
-    @Override
-    public void traceBlockPowerEnd(GlowBlock block, RSManager rsManager, int power) {
-        // Handle power change.
-        Material mat = getMaterial();
-        if(mat == Material.REDSTONE_TORCH_ON && power == 0) {
-            mat = Material.REDSTONE_TORCH_OFF;
-            block.setTypeIdAndData(mat.getId(), (byte)block.getData(), false);
-        } else if(mat == Material.REDSTONE_TORCH_OFF && power != 0) {
-            mat = Material.REDSTONE_TORCH_ON;
-            block.setTypeIdAndData(mat.getId(), (byte)block.getData(), false);
-        }
-
-        rsManager.addSource(block);
-    }
-
-    /**
-     * Trace a redstone pulse from an RS torch outwards.
-     * NOTE: This function can be extended to cater for inPower and isDirect, need-permitting.
-     * @param srcBlock The block we are flowing from.
-     * @param rsManager The RSManager used for tracking.
-     * @param forbidDir The direction we cannot flow in due to it leading back to our source.
-     * @param toDir The direction of redstone flow from this block.
-     * @param isDirect Whether the flow is direct or not.
-     */
-    private void traceBlockPowerFromRSTorch(GlowBlock srcBlock, RSManager rsManager, BlockFace forbidDir, BlockFace toDir, boolean isDirect) {
-        // Get the forbidDir check out of the way.
-        if(forbidDir == toDir) {
-            return;
-        }
-
-        // Trace outwards.
-        rsManager.traceFromBlock(srcBlock, toDir, 15, isDirect);
-    }
-
-    @Override
-    public void traceBlockPowerInit(GlowBlock block, RSManager rsManager) {
-        Material thisMat = getMaterial();
-        if(thisMat == Material.REDSTONE_TORCH_ON) {
-            // Set the charge to ensure that this is handled next tick.
-            rsManager.setBlockPower(block, 15, false);
-        } else if(thisMat == Material.REDSTONE_TORCH_OFF) {
-            // Set the charge now.
-            // If it needs to stay discharged, it will be discharged by other blocks.
-            rsManager.setBlockPower(block, 15, false);
-        }
-    }
-
-    @Override
-    public void traceBlockPowerStart(GlowBlock block, RSManager rsManager) {
-        // Abandon ship if this is not a charged RS torch.
-        Material thisMat = getMaterial();
-        if(thisMat != Material.REDSTONE_TORCH_ON) {
-            return;
-        }
-
-        // Trace in all directions except self.
-        BlockFace selfDir = getOwnFacing(block).getOppositeFace();
-        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.UP, true);
-        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.DOWN, false);
-        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.NORTH, false);
-        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.SOUTH, false);
-        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.WEST, false);
-        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.EAST, false);
-    }
-
-    @Override
-    public void traceBlockPower(GlowBlock block, RSManager rsManager, Material srcMat, BlockFace flowDir, int inPower, boolean isDirect) {
-        // Abandon ship if this is just a regular torch.
-        Material thisMat = getMaterial();
-        if(thisMat != Material.REDSTONE_TORCH_ON && thisMat != Material.REDSTONE_TORCH_OFF) {
-            return;
-        }
-        // Determine if we are getting this from a source.
-        boolean isSource = (getOwnFacing(block) == flowDir);
-        if(isSource) {
-            // Discharge this torch.
-            rsManager.setBlockPower(block, 0, false);
-        } else {
-            // Disregard this.
-        }
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
@@ -126,7 +126,7 @@ public class BlockTorch extends BlockType {
         // Trace in all directions except self.
         BlockFace selfDir = getOwnFacing(block).getOppositeFace();
         traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.UP, true);
-        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.DOWN, true);
+        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.DOWN, false);
         traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.NORTH, false);
         traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.SOUTH, false);
         traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.WEST, false);

--- a/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
@@ -10,12 +10,17 @@ import org.bukkit.util.Vector;
 
 import java.util.*;
 
-public class BlockTorch extends BlockType {
+public class BlockTorch extends BlockDirectDrops {
 
     private final Material matType;
 
-    public BlockTorch(Material matType) {
+    protected BlockTorch(Material matType, Material dropMatType) {
+        super(dropMatType, 0, 1);
         this.matType = matType;
+    }
+
+    public BlockTorch(Material matType) {
+        this(matType, matType);
     }
 
     protected BlockFace getOwnFacing(GlowBlock block) {
@@ -52,10 +57,5 @@ public class BlockTorch extends BlockType {
     public void placeBlock(GlowPlayer player, GlowBlockState state, BlockFace face, ItemStack holding, Vector clickedLoc) {
         state.setType(matType);
         state.setRawData((byte)getFacing(face));
-    }
-
-    @Override
-    public Collection<ItemStack> getDrops(GlowBlock block) {
-        return Collections.unmodifiableList(Arrays.asList(new ItemStack(matType, 1, (byte)0)));
     }
 } 

--- a/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
@@ -1,5 +1,6 @@
 package net.glowstone.block.blocktype;
 
+import net.glowstone.RSManager;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.entity.GlowPlayer;
@@ -17,6 +18,21 @@ public class BlockTorch extends BlockType {
         this.matType = matType;
     }
 
+    private BlockFace getOwnFacing(GlowBlock block) {
+        switch(block.getData()) {
+            case 1:
+                return BlockFace.EAST;
+            case 2:
+                return BlockFace.WEST;
+            case 3:
+                return BlockFace.SOUTH;
+            case 4:
+                return BlockFace.NORTH;
+            default:
+                return BlockFace.UP;
+        }
+    }
+
     private int getFacing(BlockFace face) {
         switch (face) {
             case EAST:
@@ -30,6 +46,102 @@ public class BlockTorch extends BlockType {
         }
 
         return 5;
+    }
+
+    @Override
+    public int getBlockPower(GlowBlock block, BlockFace face, boolean isDirect) {
+        if(block.getType() == Material.REDSTONE_TORCH_ON) {
+            if(face != getOwnFacing(block).getOppositeFace()) {
+                return 15;
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean isRedSource(GlowBlock block) {
+        Material thisMat = getMaterial();
+        return thisMat == Material.REDSTONE_TORCH_ON || thisMat == Material.REDSTONE_TORCH_OFF;
+    }
+
+    @Override
+    public void traceBlockPowerEnd(GlowBlock block, RSManager rsManager, int power) {
+        // Handle power change.
+        // TODO: make this actually work
+        Material mat = block.getType();
+        if(mat == Material.REDSTONE_TORCH_ON && power == 0) {
+            mat = Material.REDSTONE_TORCH_OFF;
+            block.setTypeIdAndData(mat.getId(), (byte)block.getTypeId(), false);
+        } else if(mat == Material.REDSTONE_TORCH_OFF && power != 0) {
+            mat = Material.REDSTONE_TORCH_ON;
+            block.setTypeIdAndData(mat.getId(), (byte)block.getTypeId(), false);
+        }
+
+        rsManager.addSource(block);
+    }
+
+    /**
+     * Trace a redstone pulse from an RS torch outwards.
+     * NOTE: This function can be extended to cater for inPower and isDirect, need-permitting.
+     * @param srcBlock The block we are flowing from.
+     * @param rsManager The RSManager used for tracking.
+     * @param blockDir The direction we cannot flow in due to it leading back to our source.
+     * @param toDir The direction of redstone flow from this block.
+     * @param isDirect Whether the flow is direct or not.
+     */
+    private void traceBlockPowerFromRSTorch(GlowBlock srcBlock, RSManager rsManager, BlockFace blockDir, BlockFace toDir, boolean isDirect) {
+        // Get the blockDir check out of the way.
+        if(blockDir == toDir) {
+            return;
+        }
+
+        // Trace outwards.
+        rsManager.traceFromBlock(srcBlock, toDir, 15, isDirect);
+    }
+
+    @Override
+    public void traceBlockPowerInit(GlowBlock block, RSManager rsManager) {
+        Material thisMat = getMaterial();
+        if(thisMat == Material.REDSTONE_TORCH_ON) {
+            rsManager.setBlockCharge(block, 15, false);
+        } else if(thisMat == Material.REDSTONE_TORCH_OFF) {
+            // Set the charge so it can be restored on the next tick
+            rsManager.setBlockCharge(block, 15, false);
+        }
+    }
+
+    @Override
+    public void traceBlockPowerStart(GlowBlock block, RSManager rsManager) {
+        // Abandon ship if this is not a charged RS torch.
+        Material thisMat = getMaterial();
+        if(thisMat != Material.REDSTONE_TORCH_ON) {
+            return;
+        }
+
+        // Trace in all directions except self.
+        BlockFace selfDir = getOwnFacing(block).getOppositeFace();
+        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.UP, true);
+        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.NORTH, false);
+        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.SOUTH, false);
+        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.WEST, false);
+        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.EAST, false);
+    }
+
+    @Override
+    public void traceBlockPower(GlowBlock block, RSManager rsManager, Material srcMat, BlockFace flowDir, int inPower, boolean isDirect) {
+        // Abandon ship if this is just a regular torch.
+        Material thisMat = getMaterial();
+        if(thisMat != Material.REDSTONE_TORCH_ON && thisMat != Material.REDSTONE_TORCH_OFF) {
+            return;
+        }
+        // Determine if we are getting this from a source.
+        boolean isSource = (getOwnFacing(block) == flowDir);
+        if(isSource) {
+            // Discharge this torch.
+            rsManager.setBlockCharge(block, 0, false);
+        } else {
+            // Disregard this.
+        }
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
@@ -42,5 +42,4 @@ public class BlockTorch extends BlockType {
     public Collection<ItemStack> getDrops(GlowBlock block) {
         return Collections.unmodifiableList(Arrays.asList(new ItemStack(matType, 1, (byte)0)));
     }
-}
-
+} 

--- a/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
@@ -49,13 +49,18 @@ public class BlockTorch extends BlockType {
     }
 
     @Override
-    public int getBlockPower(GlowBlock block, BlockFace face, boolean isDirect) {
-        if(block.getType() == Material.REDSTONE_TORCH_ON) {
-            if(face != getOwnFacing(block).getOppositeFace()) {
-                return 15;
-            }
+    public boolean isBlockEmittingPower(GlowBlock block, BlockFace face, boolean isDirect) {
+        // Torches do not emit behind themselves
+        if (face == getOwnFacing(block).getOppositeFace()) {
+            return false;
         }
-        return 0;
+
+        // Direct emissions ONLY go up
+        if (face != BlockFace.UP && !isDirect) {
+            return false;
+        }
+
+        return true;
     }
 
     @Override
@@ -103,10 +108,10 @@ public class BlockTorch extends BlockType {
     public void traceBlockPowerInit(GlowBlock block, RSManager rsManager) {
         Material thisMat = getMaterial();
         if(thisMat == Material.REDSTONE_TORCH_ON) {
-            rsManager.setBlockCharge(block, 15, false);
+            rsManager.setBlockPower(block, 15, false);
         } else if(thisMat == Material.REDSTONE_TORCH_OFF) {
             // Set the charge so it can be restored on the next tick
-            rsManager.setBlockCharge(block, 15, false);
+            rsManager.setBlockPower(block, 15, false);
         }
     }
 
@@ -138,7 +143,7 @@ public class BlockTorch extends BlockType {
         boolean isSource = (getOwnFacing(block) == flowDir);
         if(isSource) {
             // Discharge this torch.
-            rsManager.setBlockCharge(block, 0, false);
+            rsManager.setBlockPower(block, 0, false);
         } else {
             // Disregard this.
         }

--- a/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
@@ -49,7 +49,7 @@ public class BlockTorch extends BlockType {
     }
 
     @Override
-    public boolean isBlockEmittingPower(GlowBlock block, BlockFace face, boolean isDirect) {
+    public boolean canBlockEmitPower(GlowBlock block, BlockFace face, boolean isDirect) {
         // Torches do not emit behind themselves
         if (face == getOwnFacing(block).getOppositeFace()) {
             return false;
@@ -72,8 +72,7 @@ public class BlockTorch extends BlockType {
     @Override
     public void traceBlockPowerEnd(GlowBlock block, RSManager rsManager, int power) {
         // Handle power change.
-        // TODO: make this actually work
-        Material mat = block.getType();
+        Material mat = getMaterial();
         if(mat == Material.REDSTONE_TORCH_ON && power == 0) {
             mat = Material.REDSTONE_TORCH_OFF;
             block.setTypeIdAndData(mat.getId(), (byte)block.getData(), false);
@@ -90,13 +89,13 @@ public class BlockTorch extends BlockType {
      * NOTE: This function can be extended to cater for inPower and isDirect, need-permitting.
      * @param srcBlock The block we are flowing from.
      * @param rsManager The RSManager used for tracking.
-     * @param blockDir The direction we cannot flow in due to it leading back to our source.
+     * @param forbidDir The direction we cannot flow in due to it leading back to our source.
      * @param toDir The direction of redstone flow from this block.
      * @param isDirect Whether the flow is direct or not.
      */
-    private void traceBlockPowerFromRSTorch(GlowBlock srcBlock, RSManager rsManager, BlockFace blockDir, BlockFace toDir, boolean isDirect) {
-        // Get the blockDir check out of the way.
-        if(blockDir == toDir) {
+    private void traceBlockPowerFromRSTorch(GlowBlock srcBlock, RSManager rsManager, BlockFace forbidDir, BlockFace toDir, boolean isDirect) {
+        // Get the forbidDir check out of the way.
+        if(forbidDir == toDir) {
             return;
         }
 
@@ -108,9 +107,11 @@ public class BlockTorch extends BlockType {
     public void traceBlockPowerInit(GlowBlock block, RSManager rsManager) {
         Material thisMat = getMaterial();
         if(thisMat == Material.REDSTONE_TORCH_ON) {
+            // Set the charge to ensure that this is handled next tick.
             rsManager.setBlockPower(block, 15, false);
         } else if(thisMat == Material.REDSTONE_TORCH_OFF) {
-            // Set the charge so it can be restored on the next tick
+            // Set the charge now.
+            // If it needs to stay discharged, it will be discharged by other blocks.
             rsManager.setBlockPower(block, 15, false);
         }
     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
@@ -1,0 +1,46 @@
+package net.glowstone.block.blocktype;
+
+import net.glowstone.block.GlowBlock;
+import net.glowstone.block.GlowBlockState;
+import net.glowstone.entity.GlowPlayer;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+
+import java.util.*;
+
+public class BlockTorch extends BlockType {
+    private final Material matType;
+
+    public BlockTorch(Material matType) {
+        this.matType = matType;
+    }
+
+    private int getFacing(BlockFace face) {
+        switch (face) {
+            case EAST:
+                return 1;
+            case WEST:
+                return 2;
+            case SOUTH:
+                return 3;
+            case NORTH:
+                return 4;
+        }
+
+        return 5;
+    }
+
+    @Override
+    public void placeBlock(GlowPlayer player, GlowBlockState state, BlockFace face, ItemStack holding, Vector clickedLoc) {
+        state.setType(matType);
+        state.setRawData((byte)getFacing(face));
+    }
+
+    @Override
+    public Collection<ItemStack> getDrops(GlowBlock block) {
+        return Collections.unmodifiableList(Arrays.asList(new ItemStack(matType, 1, (byte)0)));
+    }
+}
+

--- a/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
@@ -126,6 +126,7 @@ public class BlockTorch extends BlockType {
         // Trace in all directions except self.
         BlockFace selfDir = getOwnFacing(block).getOppositeFace();
         traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.UP, true);
+        traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.DOWN, true);
         traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.NORTH, false);
         traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.SOUTH, false);
         traceBlockPowerFromRSTorch(block, rsManager, selfDir, BlockFace.WEST, false);

--- a/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockTorch.java
@@ -71,10 +71,10 @@ public class BlockTorch extends BlockType {
         Material mat = block.getType();
         if(mat == Material.REDSTONE_TORCH_ON && power == 0) {
             mat = Material.REDSTONE_TORCH_OFF;
-            block.setTypeIdAndData(mat.getId(), (byte)block.getTypeId(), false);
+            block.setTypeIdAndData(mat.getId(), (byte)block.getData(), false);
         } else if(mat == Material.REDSTONE_TORCH_OFF && power != 0) {
             mat = Material.REDSTONE_TORCH_ON;
-            block.setTypeIdAndData(mat.getId(), (byte)block.getTypeId(), false);
+            block.setTypeIdAndData(mat.getId(), (byte)block.getData(), false);
         }
 
         rsManager.addSource(block);

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -197,13 +197,14 @@ public class BlockType extends ItemType {
     // Redstone
 
     /**
-     * Determines whether redstone is emitted from this face or not.
+     * Determines whether redstone can be emitted from this face or not.
      * @param block The block we are operating on.
      * @param face The face of the block that is being touched, or SELF for internal charge.
      * @param isDirect Whether we are looking for direct or indirect power.
      */
-    public boolean isBlockEmittingPower(GlowBlock block, BlockFace face, boolean isDirect) {
-        return true;
+    public boolean canBlockEmitPower(GlowBlock block, BlockFace face, boolean isDirect) {
+        Material mat = getMaterial();
+        return (mat != null && mat.isOccluding());
     }
 
     /**
@@ -252,13 +253,13 @@ public class BlockType extends ItemType {
      * NOTE: This function can be extended to cater for inPower and isDirect, need-permitting.
      * @param srcBlock The block we are flowing from.
      * @param rsManager The RSManager used for tracking.
-     * @param blockDir The direction we cannot flow in due to it leading back to our source.
+     * @param forbidDir The direction we cannot flow in due to it leading back to our source.
      * @param toDir The direction of redstone flow from this block.
      * @param isDirect Whether we are applying direct or indirect power.
      */
-    private void traceBlockPowerSolidToBlock(GlowBlock srcBlock, RSManager rsManager, BlockFace blockDir, BlockFace toDir, boolean isDirect) {
-        // Get the blockDir check out of the way.
-        if(blockDir == toDir) {
+    private void traceBlockPowerSolidToBlock(GlowBlock srcBlock, RSManager rsManager, BlockFace forbidDir, BlockFace toDir, boolean isDirect) {
+        // Get the forbidDir check out of the way.
+        if(forbidDir == toDir) {
             return;
         }
 
@@ -292,9 +293,6 @@ public class BlockType extends ItemType {
      * @param rsManager The RSManager used for tracking.
      */
     public void traceBlockPowerStart(GlowBlock block, RSManager rsManager) {
-        // TODO: Make note of this block's "charge" level
-        // (will be necessary once we get onto implementing repeaters)
-
         // Check if solid
         if(block.getType() == null || !block.getType().isOccluding()) {
             return;

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -294,6 +294,11 @@ public class BlockType extends ItemType {
         // TODO: Make note of this block's "charge" level
         // (will be necessary once we get onto implementing repeaters)
 
+        // Check if glass
+        if(block.getType() == Material.GLASS) {
+            return;
+        }
+
         traceBlockPowerStartSolid(block, rsManager, BlockFace.UP, false);
         traceBlockPowerStartSolid(block, rsManager, BlockFace.DOWN, false);
         traceBlockPowerStartSolid(block, rsManager, BlockFace.NORTH, false);
@@ -312,6 +317,11 @@ public class BlockType extends ItemType {
      * @param isDirect Whether we are applying direct or indirect power.
      */
     public void traceBlockPower(GlowBlock block, RSManager rsManager, Material srcMat, BlockFace flowDir, int inPower, boolean isDirect) {
+        // Check if glass
+        if(block.getType() == Material.GLASS) {
+            return;
+        }
+
         // Ensure directness
         if(isDirect) {
             rsManager.addSource(block);

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -12,6 +12,7 @@ import net.glowstone.block.itemtype.ItemType;
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.block.BlockPlaceEvent;

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -3,6 +3,7 @@ package net.glowstone.block.blocktype;
 import net.glowstone.EventFactory;
 import net.glowstone.GlowChunk;
 import net.glowstone.GlowServer;
+import net.glowstone.RSManager;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.ItemTable;
@@ -189,6 +190,118 @@ public class BlockType extends ItemType {
         if (player.getGameMode() != GameMode.CREATIVE) {
             holding.setAmount(holding.getAmount() - 1);
         }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Redstone
+
+    /**
+     * Get this block's power level.
+     * @param block The block we are operating on.
+     * @param face The face of the block that is being touched, or SELF for internal charge.
+     * @param isDirect Whether we are looking for direct or indirect power.
+     */
+    public int getBlockPower(GlowBlock block, BlockFace face, boolean isDirect) {
+        // TODO.
+        return 0;
+    }
+
+    /**
+     * Checks if this block is a suitable source to add to an RSManager.
+     * This function is called on chunk loads.
+     * @param block The block we are querying.
+     */
+    public boolean isRedSource(GlowBlock block) {
+        return false;
+    }
+
+    /**
+     * Update redstone state at the end of a redstone pulse.
+     * @param block The block we are modifying.
+     * @param rsManager The RSManager used for tracking.
+     * @param power The final power level.
+     */
+    public void traceBlockPowerEnd(GlowBlock block, RSManager rsManager, int power) {
+        if(power > 0) {
+            rsManager.addSource(block);
+        }
+        // TODO: Charge solids properly
+    }
+
+    /**
+     * Trace a redstone pulse from a solid to a redstone torch.
+     * NOTE: This function can be extended to cater for inPower and isDirect, need-permitting.
+     * @param srcBlock The block we are flowing from.
+     * @param rsManager The RSManager used for tracking.
+     * @param blockDir The direction we cannot flow in due to it leading back to our source.
+     * @param toDir The direction of redstone flow from this block.
+     */
+    private void traceBlockPowerSolidToRSTorch(GlowBlock srcBlock, RSManager rsManager, BlockFace blockDir, BlockFace toDir) {
+        // Get the blockDir check out of the way.
+        if(blockDir == toDir) {
+            return;
+        }
+
+        // Get the destination block and ensure that it is a redstone torch.
+        GlowBlock destBlock = srcBlock.getRelative(toDir);
+        if(destBlock == null) {
+            return;
+        }
+        Material destMat = destBlock.getType();
+        if(destMat != Material.REDSTONE_TORCH_ON && destMat != Material.REDSTONE_TORCH_OFF) {
+            return;
+        }
+
+        // Trace to torch.
+        rsManager.traceFromBlock(srcBlock, toDir, 1, true);
+    }
+
+    /**
+     * Prepare for a redstone trace.
+     * @param block The block we are operating on.
+     * @param rsManager The RSManager used for tracking.
+     */
+    public void traceBlockPowerInit(GlowBlock block, RSManager rsManager) {
+    }
+
+    /**
+     * Begin tracing a redstone pulse as a source.
+     * @param block The block we are operating on.
+     * @param rsManager The RSManager used for tracking.
+     */
+    public void traceBlockPowerStart(GlowBlock block, RSManager rsManager) {
+        // Trace in all appropriate directions.
+        rsManager.traceFromBlockIfUnpowered(block, BlockFace.UP, 15, true);
+        rsManager.traceFromBlockIfUnpowered(block, BlockFace.DOWN, 15, true);
+        rsManager.traceFromBlockIfUnpowered(block, BlockFace.NORTH, 15, true);
+        rsManager.traceFromBlockIfUnpowered(block, BlockFace.SOUTH, 15, true);
+        rsManager.traceFromBlockIfUnpowered(block, BlockFace.WEST, 15, true);
+        rsManager.traceFromBlockIfUnpowered(block, BlockFace.EAST, 15, true);
+    }
+
+    /**
+     * Trace a redstone pulse from an external source.
+     * @param block The block we are operating on.
+     * @param rsManager The RSManager used for tracking.
+     * @param srcMat The material this pulse is coming from.
+     * @param flowDir The direction of redstone flow towards this block.
+     * @param inPower The input power level.
+     * @param isDirect Whether we are applying direct or indirect power.
+     */
+    public void traceBlockPower(GlowBlock block, RSManager rsManager, Material srcMat, BlockFace flowDir, int inPower, boolean isDirect) {
+        // Ensure directness
+        if(!isDirect) {
+            return;
+        }
+
+        // Spread to neighbours
+        BlockFace oppDir = flowDir.getOppositeFace();
+        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.UP);
+        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.DOWN);
+        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.NORTH);
+        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.SOUTH);
+        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.WEST);
+        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.EAST);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -295,8 +295,8 @@ public class BlockType extends ItemType {
         // TODO: Make note of this block's "charge" level
         // (will be necessary once we get onto implementing repeaters)
 
-        // Check if glass
-        if(block.getType() == Material.GLASS) {
+        // Check if solid
+        if(block.getType() == null || !block.getType().isOccluding()) {
             return;
         }
 
@@ -318,8 +318,8 @@ public class BlockType extends ItemType {
      * @param isDirect Whether we are applying direct or indirect power.
      */
     public void traceBlockPower(GlowBlock block, RSManager rsManager, Material srcMat, BlockFace flowDir, int inPower, boolean isDirect) {
-        // Check if glass
-        if(block.getType() == Material.GLASS) {
+        // Check if solid
+        if(block.getType() == null || !block.getType().isOccluding()) {
             return;
         }
 

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -196,18 +196,17 @@ public class BlockType extends ItemType {
     // Redstone
 
     /**
-     * Get this block's power level.
+     * Determines whether redstone is emitted from this face or not.
      * @param block The block we are operating on.
      * @param face The face of the block that is being touched, or SELF for internal charge.
      * @param isDirect Whether we are looking for direct or indirect power.
      */
-    public int getBlockPower(GlowBlock block, BlockFace face, boolean isDirect) {
-        // TODO.
-        return 0;
+    public boolean isBlockEmittingPower(GlowBlock block, BlockFace face, boolean isDirect) {
+        return true;
     }
 
     /**
-     * Checks if this block is a suitable source to add to an RSManager.
+     * Checks if this block is a suitable source to add to an RSManager initially.
      * This function is called on chunk loads.
      * @param block The block we are querying.
      */
@@ -235,8 +234,9 @@ public class BlockType extends ItemType {
      * @param rsManager The RSManager used for tracking.
      * @param blockDir The direction we cannot flow in due to it leading back to our source.
      * @param toDir The direction of redstone flow from this block.
+     * @param isDirect Whether we are applying direct or indirect power.
      */
-    private void traceBlockPowerSolidToRSTorch(GlowBlock srcBlock, RSManager rsManager, BlockFace blockDir, BlockFace toDir) {
+    private void traceBlockPowerSolidToRSTorch(GlowBlock srcBlock, RSManager rsManager, BlockFace blockDir, BlockFace toDir, boolean isDirect) {
         // Get the blockDir check out of the way.
         if(blockDir == toDir) {
             return;
@@ -257,6 +257,17 @@ public class BlockType extends ItemType {
     }
 
     /**
+     * Trace a redstone pulse from a starting solid.
+     * @param srcBlock The block we are flowing from.
+     * @param rsManager The RSManager used for tracking.
+     * @param toDir The direction of redstone flow from this block.
+     * @param isDirect Whether we are applying direct or indirect power.
+     */
+    private void traceBlockPowerStartSolid(GlowBlock srcBlock, RSManager rsManager, BlockFace toDir, boolean isDirect) {
+        // XXX: I really don't know what to do here just yet.
+    }
+
+    /**
      * Prepare for a redstone trace.
      * @param block The block we are operating on.
      * @param rsManager The RSManager used for tracking.
@@ -270,13 +281,15 @@ public class BlockType extends ItemType {
      * @param rsManager The RSManager used for tracking.
      */
     public void traceBlockPowerStart(GlowBlock block, RSManager rsManager) {
-        // Trace in all appropriate directions.
-        rsManager.traceFromBlockIfUnpowered(block, BlockFace.UP, 15, true);
-        rsManager.traceFromBlockIfUnpowered(block, BlockFace.DOWN, 15, true);
-        rsManager.traceFromBlockIfUnpowered(block, BlockFace.NORTH, 15, true);
-        rsManager.traceFromBlockIfUnpowered(block, BlockFace.SOUTH, 15, true);
-        rsManager.traceFromBlockIfUnpowered(block, BlockFace.WEST, 15, true);
-        rsManager.traceFromBlockIfUnpowered(block, BlockFace.EAST, 15, true);
+        // TODO: Make note of this block's "charge" level
+        // (will be necessary once we get onto implementing repeaters)
+
+        traceBlockPowerStartSolid(block, rsManager, BlockFace.UP, false);
+        traceBlockPowerStartSolid(block, rsManager, BlockFace.DOWN, false);
+        traceBlockPowerStartSolid(block, rsManager, BlockFace.NORTH, false);
+        traceBlockPowerStartSolid(block, rsManager, BlockFace.SOUTH, false);
+        traceBlockPowerStartSolid(block, rsManager, BlockFace.WEST, false);
+        traceBlockPowerStartSolid(block, rsManager, BlockFace.EAST, false);
     }
 
     /**
@@ -291,17 +304,19 @@ public class BlockType extends ItemType {
     public void traceBlockPower(GlowBlock block, RSManager rsManager, Material srcMat, BlockFace flowDir, int inPower, boolean isDirect) {
         // Ensure directness
         if(!isDirect) {
-            return;
+            if(srcMat != Material.REDSTONE_WIRE) {
+                return;
+            }
         }
 
         // Spread to neighbours
         BlockFace oppDir = flowDir.getOppositeFace();
-        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.UP);
-        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.DOWN);
-        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.NORTH);
-        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.SOUTH);
-        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.WEST);
-        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.EAST);
+        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.UP, isDirect);
+        //traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.DOWN, isDirect);
+        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.NORTH, isDirect);
+        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.SOUTH, isDirect);
+        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.WEST, isDirect);
+        traceBlockPowerSolidToRSTorch(block, rsManager, oppDir, BlockFace.EAST, isDirect);
     }
 
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is just the start of a redstone framework which actually ended up being somewhat different from the initial prototype.

This is for issue #116 Redstone Support. I have dropped the WIP tag as I am satisfied that I have a suitable working subset of RS functionality (even though the torch timing is 1-tick rather than 2-tick).

Current status:
- **DONE** - RSManager class tied to world to handle the redstone network
- **DONE** - Chunks are dirtied, updated and unloaded by GlowWorld and GlowChunk
- **DONE** - pulse() method hooked up to GlowWorld
- **DONE** - Actually load chunk data into RSManager
- **DONE** - Redstone torch blocks
- **DONE** - Basic redstone logic
  - **DONE** - Redstone torch->solid->torch sequence
  - **DONE** - Redstone wires - diagonals ARE blocked, and these ARE analogue! (NEW: "injection" and charging of solids)
- **FIXED ITSELF?!** - Actually relay redstone updates to client (should be there BUT there's some stupid bug somewhere which is preventing this from actually working)
- **DONE** - Prevent placement of redstone dust ("wires") on a lot of things (mostly RS dust, RS torches)

To be implemented in later pull requests:
- Actually deregister chunks properly
- Faster deregistering of chunks
- Proper network creation which doesn't require tracing wires every pulse (prototype uses HashSets to mark positions of "sources", torches, and charged wires - it's not going to hit _every_ block each frame!)
- Repeaters
- Comparators
