### PR TITLE
disable block breaking in creative holding sword

### DIFF
--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -55,7 +55,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
                 if (damageEvent.isCancelled()) {
                     revert = true;
                 } else if(gamemode == GameMode.CREATIVE && EnchantmentTarget.WEAPON.includes(holding)) {
-                revert = true;
+                    revert = true;
                 } else {
                     blockBroken = damageEvent.getInstaBreak();
                 }
@@ -67,7 +67,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
             BlockBreakEvent event = EventFactory.onBlockBreak(block, player);
             if (event.isCancelled()) {
                 revert = true;
-            }  else {
+            } else {
                 blockBroken = true;
             }
         } else {

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -54,7 +54,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
                 BlockDamageEvent damageEvent = EventFactory.onBlockDamage(player, block);
                 if (damageEvent.isCancelled()) {
                     revert = true;
-                } else if(gamemode == GameMode.CREATIVE && holding.getType() == Material.STONE_SWORD || holding.getType() == Material.WOOD_SWORD || holding.getType() == Material.IRON_SWORD || holding.getType() == Material.DIAMOND_SWORD || holding.getType() == Material.GOLD_SWORD) {
+                } else if(gamemode == GameMode.CREATIVE && EnchantmentTarget.WEAPON.includes(holding) {
                 revert = true;
                 } else {
                     blockBroken = damageEvent.getInstaBreak();

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -54,7 +54,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
                 BlockDamageEvent damageEvent = EventFactory.onBlockDamage(player, block);
                 if (damageEvent.isCancelled()) {
                     revert = true;
-                } else if(gamemode == GameMode.CREATIVE && EnchantmentTarget.WEAPON.includes(holding) {
+                } else if(gamemode == GameMode.CREATIVE && holding.getType() == Material.STONE_SWORD || holding.getType() == Material.WOOD_SWORD || holding.getType() == Material.IRON_SWORD || holding.getType() == Material.DIAMOND_SWORD || holding.getType() == Material.GOLD_SWORD) {
                 revert = true;
                 } else {
                     blockBroken = damageEvent.getInstaBreak();

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -4,6 +4,7 @@ import com.flowpowered.networking.MessageHandler;
 import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
+import net.glowstone.block.ItemTable;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.DiggingMessage;
@@ -28,6 +29,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
         GlowBlock block = world.getBlockAt(x, y, z);
         BlockFace face = BlockPlacementHandler.convertFace(message.getFace());
         ItemStack holding = player.getItemInHand();
+        GameMode gamemode = player.getGameMode();
 
 
         boolean blockBroken = false;
@@ -52,6 +54,8 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
                 BlockDamageEvent damageEvent = EventFactory.onBlockDamage(player, block);
                 if (damageEvent.isCancelled()) {
                     revert = true;
+                } else if(gamemode == GameMode.CREATIVE && holding.getType() == Material.STONE_SWORD || holding.getType() == Material.WOOD_SWORD || holding.getType() == Material.IRON_SWORD || holding.getType() == Material.DIAMOND_SWORD || holding.getType() == Material.GOLD_SWORD) {
+                revert = true;
                 } else {
                     blockBroken = damageEvent.getInstaBreak();
                 }
@@ -63,7 +67,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
             BlockBreakEvent event = EventFactory.onBlockBreak(block, player);
             if (event.isCancelled()) {
                 revert = true;
-            } else {
+            }  else {
                 blockBroken = true;
             }
         } else {

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -54,8 +54,8 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
                 BlockDamageEvent damageEvent = EventFactory.onBlockDamage(player, block);
                 if (damageEvent.isCancelled()) {
                     revert = true;
-                } else if(gamemode == GameMode.CREATIVE && holding.getType() == Material.STONE_SWORD || holding.getType() == Material.WOOD_SWORD || holding.getType() == Material.IRON_SWORD || holding.getType() == Material.DIAMOND_SWORD || holding.getType() == Material.GOLD_SWORD) {
-                revert = true;
+                } else if(gamemode == GameMode.CREATIVE && EnchantmentTarget.WEAPON.includes(holding)) {
+                    revert = true;
                 } else {
                     blockBroken = damageEvent.getInstaBreak();
                 }

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -67,7 +67,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
             BlockBreakEvent event = EventFactory.onBlockBreak(block, player);
             if (event.isCancelled()) {
                 revert = true;
-            }  else {
+            } else {
                 blockBroken = true;
             }
         } else {

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -4,7 +4,6 @@ import com.flowpowered.networking.MessageHandler;
 import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
-import net.glowstone.block.ItemTable;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.DiggingMessage;
@@ -18,8 +17,10 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.enchantments.EnchantmentTarget;
 
 public final class DiggingHandler implements MessageHandler<GlowSession, DiggingMessage> {
+    @Override
     public void handle(GlowSession session, DiggingMessage message) {
         final GlowPlayer player = session.getPlayer();
         GlowWorld world = player.getWorld();
@@ -30,7 +31,6 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
         BlockFace face = BlockPlacementHandler.convertFace(message.getFace());
         ItemStack holding = player.getItemInHand();
         GameMode gamemode = player.getGameMode();
-
 
         boolean blockBroken = false;
         boolean revert = false;
@@ -55,7 +55,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
                 if (damageEvent.isCancelled()) {
                     revert = true;
                 } else if(gamemode == GameMode.CREATIVE && EnchantmentTarget.WEAPON.includes(holding)) {
-                    revert = true;
+                revert = true;
                 } else {
                     blockBroken = damageEvent.getInstaBreak();
                 }
@@ -67,7 +67,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
             BlockBreakEvent event = EventFactory.onBlockBreak(block, player);
             if (event.isCancelled()) {
                 revert = true;
-            } else {
+            }  else {
                 blockBroken = true;
             }
         } else {


### PR DESCRIPTION
This makes it so blocks cannot break when you are in creative mode and you hit the block with a sword.
Known bug: block particles appear on hit.
Fixes #214 
