### PR TITLE
Open windows for all block's that have an inventory type.

### DIFF
--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -37,6 +37,14 @@ public final class ItemTable {
     // Registration
 
     private void registerBuiltins() {
+        reg(Material.ANVIL, new BlockAnvil());
+        reg(Material.BREWING_STAND, new BlockBrewingStand());
+        reg(Material.BEACON, new BlockBeacon());
+        reg(Material.DISPENSER, new BlockDispenser());
+        reg(Material.DROPPER, new BlockDropper());
+        reg(Material.ENCHANTMENT_TABLE, new BlockEnchantmentTable());
+        reg(Material.FURNACE, new BlockFurnace());
+        reg(Material.HOPPER, new BlockHopper());
         reg(Material.NOTE_BLOCK, new BlockNote());
         reg(Material.MOB_SPAWNER, new BlockMobSpawner());
         reg(Material.SIGN_POST, new BlockSign());

--- a/src/main/java/net/glowstone/block/blocktype/BlockAnvil.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockAnvil.java
@@ -7,9 +7,9 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.util.Vector;
 
-public class BlockWorkbench extends BlockType {
+public class BlockAnvil extends BlockType {
     @Override
     public boolean blockInteract(GlowPlayer player, GlowBlock block, BlockFace face, Vector clickedLoc) {
-        return player.openBlockWindow(block.getLocation(), false, Material.WORKBENCH, InventoryType.WORKBENCH) != null;
+        return player.openBlockWindow(block.getLocation(), false, Material.ANVIL, InventoryType.ANVIL) != null;
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockBeacon.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockBeacon.java
@@ -7,9 +7,9 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.util.Vector;
 
-public class BlockWorkbench extends BlockType {
+public class BlockBeacon extends BlockType {
     @Override
     public boolean blockInteract(GlowPlayer player, GlowBlock block, BlockFace face, Vector clickedLoc) {
-        return player.openBlockWindow(block.getLocation(), false, Material.WORKBENCH, InventoryType.WORKBENCH) != null;
+        return player.openBlockWindow(block.getLocation(), false, Material.BEACON, InventoryType.BEACON) != null;
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockBrewingStand.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockBrewingStand.java
@@ -7,9 +7,10 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.util.Vector;
 
-public class BlockWorkbench extends BlockType {
+public class BlockBrewingStand extends BlockType {
     @Override
     public boolean blockInteract(GlowPlayer player, GlowBlock block, BlockFace face, Vector clickedLoc) {
-        return player.openBlockWindow(block.getLocation(), false, Material.WORKBENCH, InventoryType.WORKBENCH) != null;
+        return player.openBlockWindow(block.getLocation(), false, Material.BREWING_STAND, InventoryType.BREWING) != null;
+        //TODO add packet 0X31 (Window Property) sent after
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockDispenser.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockDispenser.java
@@ -7,9 +7,9 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.util.Vector;
 
-public class BlockWorkbench extends BlockType {
+public class BlockDispenser extends BlockType {
     @Override
     public boolean blockInteract(GlowPlayer player, GlowBlock block, BlockFace face, Vector clickedLoc) {
-        return player.openBlockWindow(block.getLocation(), false, Material.WORKBENCH, InventoryType.WORKBENCH) != null;
+        return player.openBlockWindow(block.getLocation(), false, Material.DISPENSER, InventoryType.DISPENSER) != null;
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockDropper.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockDropper.java
@@ -7,9 +7,9 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.util.Vector;
 
-public class BlockWorkbench extends BlockType {
+public class BlockDropper extends BlockType {
     @Override
     public boolean blockInteract(GlowPlayer player, GlowBlock block, BlockFace face, Vector clickedLoc) {
-        return player.openBlockWindow(block.getLocation(), false, Material.WORKBENCH, InventoryType.WORKBENCH) != null;
+        return player.openBlockWindow(block.getLocation(), false, Material.DROPPER, InventoryType.DROPPER) != null;
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockEnchantmentTable.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockEnchantmentTable.java
@@ -7,9 +7,9 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.util.Vector;
 
-public class BlockWorkbench extends BlockType {
+public class BlockEnchantmentTable extends BlockType {
     @Override
     public boolean blockInteract(GlowPlayer player, GlowBlock block, BlockFace face, Vector clickedLoc) {
-        return player.openBlockWindow(block.getLocation(), false, Material.WORKBENCH, InventoryType.WORKBENCH) != null;
+        return player.openBlockWindow(block.getLocation(), false, Material.ENCHANTMENT_TABLE, InventoryType.ENCHANTING) != null;
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockFurnace.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockFurnace.java
@@ -7,9 +7,9 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.util.Vector;
 
-public class BlockWorkbench extends BlockType {
+public class BlockFurnace extends BlockType {
     @Override
     public boolean blockInteract(GlowPlayer player, GlowBlock block, BlockFace face, Vector clickedLoc) {
-        return player.openBlockWindow(block.getLocation(), false, Material.WORKBENCH, InventoryType.WORKBENCH) != null;
+        return player.openBlockWindow(block.getLocation(), false, Material.FURNACE, InventoryType.FURNACE) != null;
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockHopper.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockHopper.java
@@ -7,9 +7,9 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.util.Vector;
 
-public class BlockWorkbench extends BlockType {
+public class BlockHopper extends BlockType {
     @Override
     public boolean blockInteract(GlowPlayer player, GlowBlock block, BlockFace face, Vector clickedLoc) {
-        return player.openBlockWindow(block.getLocation(), false, Material.WORKBENCH, InventoryType.WORKBENCH) != null;
+        return player.openBlockWindow(block.getLocation(), false, Material.HOPPER, InventoryType.HOPPER) != null;
     }
 }

--- a/src/main/java/net/glowstone/entity/GlowHumanEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowHumanEntity.java
@@ -289,28 +289,17 @@ public abstract class GlowHumanEntity extends GlowLivingEntity implements HumanE
         return view;
     }
 
-    public InventoryView openWorkbench(Location location, boolean force) {
-        if (location == null) {
+    public InventoryView openBlockWindow(Location location, boolean force, Material material, InventoryType inventorytype) {
+    	if (location == null) {
             location = getLocation();
         }
-        if (!force && location.getBlock().getType() != Material.WORKBENCH) {
-            return null;
-        }
-        return openInventory(new GlowCraftingInventory(this, InventoryType.WORKBENCH));
+    	
+    	if (!force && location.getBlock().getType() != material) {
+    		return null; 
+    	}
+    	return openInventory(new GlowCraftingInventory(this, inventorytype));
     }
-
-    public InventoryView openEnchanting(Location location, boolean force) {
-        if (location == null) {
-            location = getLocation();
-        }
-        if (!force && location.getBlock().getType() != Material.ENCHANTMENT_TABLE) {
-            return null;
-        }
-        // todo: actually open
-        /*InventoryView view = new GlowInventoryView(this, new GlowEnchantInventory() ...);*/
-        return null;
-    }
-
+    
     public void openInventory(InventoryView inventory) {
         Validate.notNull(inventory);
         this.inventory.getDragTracker().reset();

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -32,8 +32,13 @@ import org.bukkit.conversations.Conversation;
 import org.bukkit.conversations.ConversationAbandonedEvent;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.*;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.bukkit.inventory.AnvilInventory;
+import org.bukkit.inventory.BrewerInventory;
+import org.bukkit.inventory.CraftingInventory;
+import org.bukkit.inventory.EnchantingInventory;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
@@ -1358,12 +1363,18 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         invMonitor = new InventoryMonitor(getOpenInventory());
         int viewId = invMonitor.getId();
         if (viewId != 0) {
+        	int size = view.getTopInventory().getSize();
             String title = view.getTitle();
             boolean defaultTitle = view.getType().getDefaultTitle().equals(title);
             if (view.getTopInventory() instanceof PlayerInventory && defaultTitle) {
                 title = ((PlayerInventory) view.getTopInventory()).getHolder().getName();
             }
-            Message open = new OpenWindowMessage(viewId, invMonitor.getType(), title, view.getTopInventory().getSize());
+            
+			if (view.getType() == InventoryType.WORKBENCH || view.getType() == InventoryType.ENCHANTING || view.getType() == InventoryType.ANVIL) {
+				size = 0;
+            }     
+			
+			Message open = new OpenWindowMessage(viewId, invMonitor.getType(), title, size);
             session.send(open);
         }
 
@@ -1528,4 +1539,19 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
             session.send(new PluginMessage("REGISTER", buf.array()));
         }
     }
+
+	@Override
+	public InventoryView openEnchanting(Location arg0, boolean arg1) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public InventoryView openWorkbench(Location arg0, boolean arg1) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+
+
 }

--- a/src/main/java/net/glowstone/inventory/GlowCraftingInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowCraftingInventory.java
@@ -20,8 +20,8 @@ public class GlowCraftingInventory extends GlowInventory implements CraftingInve
 
     public GlowCraftingInventory(InventoryHolder owner, InventoryType type) {
         super(owner, type);
-        if (type != InventoryType.CRAFTING && type != InventoryType.WORKBENCH) {
-            throw new IllegalArgumentException("GlowCraftingInventory cannot be " + type + ", only CRAFTING or WORKBENCH.");
+        if (type != InventoryType.CRAFTING && type != InventoryType.WORKBENCH && type != InventoryType.ENCHANTING && type != InventoryType.ANVIL && type != InventoryType.BREWING && type != InventoryType.BEACON && type != InventoryType.FURNACE  && type != InventoryType.DISPENSER && type != InventoryType.DROPPER  && type != InventoryType.HOPPER) {
+            throw new IllegalArgumentException("GlowCraftingInventory cannot be " + type + ", only CRAFTING or WORKBENCH or ENCHANTING or ANVIL or BREWING or Beacon or Furnace or Dispenser or Dropper or Hopper.");
         }
 
         slotTypes[RESULT_SLOT] = InventoryType.SlotType.RESULT;


### PR DESCRIPTION
Opens windows for all the blocks with an inventory type.
(furnace, brew stand, beacon, crafting table, dropper, hopper, enchantment table, anvil, dispenser)

Credit
johni0702 had the original pull request to fix crafting tables, the size property is suppose to be 0 not 10.
