### PR TITLE
Implement BlockContainer.getDrops()

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockContainer.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockContainer.java
@@ -5,7 +5,10 @@ import net.glowstone.block.entity.TEContainer;
 import net.glowstone.block.entity.TileEntity;
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
+import java.util.Collection;
+import java.util.LinkedList;
 
 /**
  * Base BlockType for containers.
@@ -21,6 +24,20 @@ public class BlockContainer extends BlockType {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public Collection<ItemStack> getDrops(GlowBlock block) {
+        LinkedList<ItemStack> list = new LinkedList<ItemStack>();
+
+        list.add(new ItemStack(block.getType(), 1));
+
+        for (ItemStack i : ((TEContainer) block.getTileEntity()).getInventory().getContents()) {
+            if (i != null) {
+                list.add(i);
+            }
+        }
+        return list;
     }
 
 }


### PR DESCRIPTION
Drops the container block itself, and all the items from its inventory.

Fixes the weird looking item that chests dropped (was chest + data)
