### PR TITLE
Don't return null in PlayerInventory.getItemInHand()

### DIFF
--- a/src/main/java/net/glowstone/inventory/GlowPlayerInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowPlayerInventory.java
@@ -8,6 +8,7 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.Material;
 
 import java.util.Arrays;
 
@@ -179,7 +180,14 @@ public class GlowPlayerInventory extends GlowInventory implements PlayerInventor
 
     @Override
     public ItemStack getItemInHand() {
-        return getItem(heldSlot);
+        ItemStack item = getItem(heldSlot);
+        if (item != null) {
+            return item;
+        } else {
+            /* The other implementation doesn't return null here, and
+             * plugins seem to expect this. Do the same to avoid NPEs. */
+            return new ItemStack(Material.AIR, 0);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #265 - see that ticket for more details.

Apparently getItemInHand() is the only method that needs to return
ItemStack{AIR x 0} instead of null, and plugins expect it to be like
this, and get NPEs without this patch.

Other methods (getItem, getContents, getBoots, etc) return null instead,
this one is the exception for reasons we'll never know since the source
of craftbukkit is gone. Forever.
