### PR TITLE
Call PlayerMoveEvent.

### DIFF
--- a/src/main/java/net/glowstone/net/codec/play/game/PositionRotationCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/game/PositionRotationCodec.java
@@ -24,7 +24,7 @@ public final class PositionRotationCodec implements Codec<PositionRotationMessag
         buf.writeDouble(message.getX());
         buf.writeDouble(message.getY());
         buf.writeDouble(message.getZ());
-        buf.writeFloat(message.getRotation());
+        buf.writeFloat(message.getYaw());
         buf.writeFloat(message.getPitch());
         buf.writeByte(message.getFlags());
         return buf;

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
@@ -1,22 +1,33 @@
 package net.glowstone.net.handler.play.player;
 
 import com.flowpowered.networking.MessageHandler;
+import net.glowstone.EventFactory;
 import net.glowstone.net.GlowSession;
+import net.glowstone.net.message.play.game.PositionRotationMessage;
 import net.glowstone.net.message.play.player.PlayerUpdateMessage;
 import org.bukkit.Location;
+import org.bukkit.event.player.PlayerMoveEvent;
 
 public final class PlayerUpdateHandler implements MessageHandler<GlowSession, PlayerUpdateMessage> {
 
     @Override
     public void handle(GlowSession session, PlayerUpdateMessage message) {
-        Location original = session.getPlayer().getLocation();
-        Location newLoc = original.clone();
+        Location originLoc = session.getPlayer().getLocation();
+        Location newLoc = originLoc.clone();
         message.update(newLoc);
 
         // don't let players move more than 16 blocks in a single packet.
         // this is NOT robust hack prevention - only to prevent client
         // confusion about where its actual location is (e.g. during login)
-        if (newLoc.distanceSquared(original) > 16 * 16) {
+        if (newLoc.distanceSquared(originLoc) > 16 * 16) {
+            return;
+        }
+
+        final PlayerMoveEvent event = EventFactory.onPlayerMove(session.getPlayer(), originLoc, newLoc);
+        if (event.isCancelled()) {
+            // Magic value
+            // https://github.com/JeromSar/CraftBukkit/blob/master/src/main/java/net/minecraft/server/PlayerConnection.java#L240
+            session.send(new PositionRotationMessage(originLoc, 1.6200000047683716D)); // Magic value:
             return;
         }
 

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
@@ -27,7 +27,7 @@ public final class PlayerUpdateHandler implements MessageHandler<GlowSession, Pl
         if (event.isCancelled()) {
             // Magic value
             // https://github.com/JeromSar/CraftBukkit/blob/master/src/main/java/net/minecraft/server/PlayerConnection.java#L240
-            session.send(new PositionRotationMessage(originLoc, 1.6200000047683716D)); // Magic value:
+            session.send(new PositionRotationMessage(originLoc, 1.6200000047683716D));
             return;
         }
 

--- a/src/main/java/net/glowstone/net/message/play/entity/EntityTeleportMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/entity/EntityTeleportMessage.java
@@ -51,7 +51,7 @@ public final class EntityTeleportMessage implements Message {
 
     @Override
     public String toString() {
-        return "EntityTeleportMessage{id=" + id + ",x=" + x + ",y=" + y + ",z=" + z + ",rotation=" + rotation + ",pitch=" + pitch + "}";
+        return "EntityTeleportMessage{id=" + id + ",x=" + x + ",y=" + y + ",z=" + z + ",yaw=" + rotation + ",pitch=" + pitch + "}";
     }
 
 }

--- a/src/main/java/net/glowstone/net/message/play/game/PositionRotationMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/game/PositionRotationMessage.java
@@ -6,18 +6,19 @@ import org.bukkit.Location;
 public final class PositionRotationMessage implements Message {
 
     private final double x, y, z;
-    private final float rotation, pitch;
+    private final float yaw, pitch;
     private final int flags;
 
-    public PositionRotationMessage(double x, double y, double z, float rotation, float pitch) {
-        this(x, y, z, rotation, pitch, 0);
+
+    public PositionRotationMessage(double x, double y, double z, float yaw, float pitch) {
+        this(x, y, z, yaw, pitch, 0);
     }
 
-    public PositionRotationMessage(double x, double y, double z, float rotation, float pitch, int flags) {
+    public PositionRotationMessage(double x, double y, double z, float yaw, float pitch, int flags) {
         this.x = x;
         this.y = y;
         this.z = z;
-        this.rotation = rotation;
+        this.yaw = yaw;
         this.pitch = pitch;
         this.flags = flags;
     }
@@ -38,8 +39,8 @@ public final class PositionRotationMessage implements Message {
         return z;
     }
 
-    public float getRotation() {
-        return rotation;
+    public float getYaw() {
+        return yaw;
     }
 
     public float getPitch() {
@@ -53,7 +54,7 @@ public final class PositionRotationMessage implements Message {
     @Override
     public String toString() {
         return "PositionRotationMessage{x=" + x + ",y=" + y + ",z=" + z +
-                ",rotation=" + rotation + ",pitch=" +
+                ",rotation=" + yaw + ",pitch=" +
                 pitch + ",flags=" + flags + "}";
     }
 }


### PR DESCRIPTION
Currently, PlayerMoveEvent is not called. This Pull Request adds functionality to address this.

By carefully inspecting CraftBukkit and NMS code, The right packet is called when the event is cancelled: _0x08 Player Rotation_ (previously known as _0x11 Player Position_).

Additionally, this pull request includes a field name refractor in PlayerRotationMessage: from _rotation_ to _yaw_.

See https://docs.google.com/spreadsheet/ccc?key=0Ai7FZY3N9uoYdFZEaU1RZUswZ2dqUFRpTTkyUEk1dXc&usp=sharing#gid=0
And https://github.com/JeromSar/CraftBukkit/blob/master/src/main/java/net/minecraft/server/PlayerConnection.java#L240
