### PR TITLE
Fix BlockEvent issues

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -11,6 +11,7 @@ import net.glowstone.block.itemtype.ItemType;
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.block.BlockPlaceEvent;
@@ -157,26 +158,28 @@ public class BlockType extends ItemType {
             }
         }
 
-        GlowBlockState newState = target.getState();
-
         // call canBuild event
         if (!EventFactory.onBlockCanBuild(target, getId(), face).isBuildable()) {
             //revert(player, target);
             return;
         }
 
+        GlowBlockState oldState = target.getState();
+        GlowBlockState newState = target.getState();
+
         // calculate new block
         placeBlock(player, newState, face, holding, clickedLoc);
 
-        // call blockPlace event
-        BlockPlaceEvent event = EventFactory.onBlockPlace(target, newState, against, player);
-        if (event.isCancelled() || !event.canBuild()) {
-            //revert(player, target);
-            return;
-        }
-
         // perform the block change
         newState.update(true);
+
+        // call blockPlace event
+        BlockPlaceEvent event = EventFactory.onBlockPlace(target, oldState, against, player);
+
+        if (event.isCancelled() || !event.canBuild()) {
+            oldState.update(true);
+            return;
+        }
 
         // play a sound effect
         // todo: vary sound effect based on block type

--- a/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
@@ -95,6 +95,10 @@ public final class BlockPlacementHandler implements MessageHandler<GlowSession, 
         PlayerInteractEvent event = EventFactory.onPlayerInteract(player, action, clicked, face);
         //GlowServer.logger.info("Interact: " + action + " " + clicked + " " + face);
 
+        if (event.isCancelled()) {
+            return;
+        }
+
         // attempt to use interacted block
         // DEFAULT is treated as ALLOW, and sneaking is always considered
         boolean useInteractedBlock = event.useInteractedBlock() != Event.Result.DENY;

--- a/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
@@ -95,10 +95,6 @@ public final class BlockPlacementHandler implements MessageHandler<GlowSession, 
         PlayerInteractEvent event = EventFactory.onPlayerInteract(player, action, clicked, face);
         //GlowServer.logger.info("Interact: " + action + " " + clicked + " " + face);
 
-        if (event.isCancelled()) {
-            return;
-        }
-
         // attempt to use interacted block
         // DEFAULT is treated as ALLOW, and sneaking is always considered
         boolean useInteractedBlock = event.useInteractedBlock() != Event.Result.DENY;

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -12,6 +12,7 @@ import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.enchantments.EnchantmentTarget;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
@@ -56,6 +57,8 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
             }
 
             if (player.getGameMode() == GameMode.CREATIVE) {
+                if (EnchantmentTarget.WEAPON.includes(player.getItemInHand().getType())) {return;}
+
                 // todo: verification against malicious clients
                 // also, if the block dig was denied, this break might still happen
                 // because a player's digging status isn't yet tracked. this is bad.
@@ -67,6 +70,10 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
                 }
             }
         } else if (message.getState() == DiggingMessage.STATE_DONE_DIGGING) {
+            if (player.getGameMode() == GameMode.CREATIVE) {
+                if (EnchantmentTarget.WEAPON.includes(player.getItemInHand().getType())) {return;}
+            }
+
             // todo: verification against malicious clients
             // also, if the block dig was denied, this break might still happen
             // because a player's digging status isn't yet tracked. this is bad.

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -41,10 +41,6 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
             }
             PlayerInteractEvent interactEvent = EventFactory.onPlayerInteract(player, action, eventBlock, face);
 
-            if (interactEvent.isCancelled()) {
-                revert = true;
-            }
-
             // blocks don't get interacted with on left click, so ignore that
             // attempt to use item in hand, that is, dig up the block
             if (!BlockPlacementHandler.selectResult(interactEvent.useItemInHand(), true)) {

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -61,7 +61,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
             }
 
             if (player.getGameMode() == GameMode.CREATIVE) {
-                if (EnchantmentTarget.WEAPON.includes(player.getItemInHand().getType())) {return;}
+                if (player.getItemInHand() != null && EnchantmentTarget.WEAPON.includes(player.getItemInHand().getType())) {return;}
 
                 // todo: verification against malicious clients
                 // also, if the block dig was denied, this break might still happen
@@ -75,7 +75,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
             }
         } else if (message.getState() == DiggingMessage.STATE_DONE_DIGGING) {
             if (player.getGameMode() == GameMode.CREATIVE) {
-                if (EnchantmentTarget.WEAPON.includes(player.getItemInHand().getType())) {return;}
+                if (player.getItemInHand() != null && EnchantmentTarget.WEAPON.includes(player.getItemInHand().getType())) {return;}
             }
 
             // todo: verification against malicious clients

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -41,6 +41,10 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
             }
             PlayerInteractEvent interactEvent = EventFactory.onPlayerInteract(player, action, eventBlock, face);
 
+            if (interactEvent.isCancelled()) {
+                revert = true;
+            }
+
             // blocks don't get interacted with on left click, so ignore that
             // attempt to use item in hand, that is, dig up the block
             if (!BlockPlacementHandler.selectResult(interactEvent.useItemInHand(), true)) {


### PR DESCRIPTION
Fixed BlockBreakEvent not being called in creative, Fix the wrong type being passed to the BlockPlaceEvent and prevented creative players from breaking blocks with swords to match vanilla behavior. Fixes #273, #271, #214 Replaces #216.
