### PR TITLE
[WIP] Scoreboard 1.8

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -212,7 +212,7 @@ public final class GlowServer implements Server {
     /**
      * The scoreboard manager for the server.
      */
-    private final ScoreboardManager scoreboardManager = new GlowScoreboardManager(this);
+    private final GlowScoreboardManager scoreboardManager = new GlowScoreboardManager(this);
 
     /**
      * The crafting manager for this server.
@@ -705,7 +705,7 @@ public final class GlowServer implements Server {
     }
 
     @Override
-    public ScoreboardManager getScoreboardManager() {
+    public GlowScoreboardManager getScoreboardManager() {
         return scoreboardManager;
     }
 

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -14,6 +14,7 @@ import net.glowstone.net.GlowNetworkServer;
 import net.glowstone.net.SessionRegistry;
 import net.glowstone.scheduler.GlowScheduler;
 import net.glowstone.scheduler.WorldScheduler;
+import net.glowstone.scoreboard.GlowScoreboardManager;
 import net.glowstone.util.*;
 import net.glowstone.util.bans.GlowBanList;
 import net.glowstone.util.bans.UuidListFile;
@@ -211,7 +212,7 @@ public final class GlowServer implements Server {
     /**
      * The scoreboard manager for the server.
      */
-    private final ScoreboardManager scoreboardManager = null;
+    private final ScoreboardManager scoreboardManager = new GlowScoreboardManager(this);
 
     /**
      * The crafting manager for this server.

--- a/src/main/java/net/glowstone/constants/GlowDisplaySlot.java
+++ b/src/main/java/net/glowstone/constants/GlowDisplaySlot.java
@@ -1,0 +1,40 @@
+package net.glowstone.constants;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.scoreboard.DisplaySlot;
+
+import java.util.Arrays;
+
+import static org.bukkit.scoreboard.DisplaySlot.*;
+
+/**
+ * ID number mappings for {@link DisplaySlot}s.
+ */
+public final class GlowDisplaySlot {
+
+    private GlowDisplaySlot() {}
+
+    private final static int[] ids = new int[DisplaySlot.values().length];
+
+    /**
+     * Get the id for a specified DisplaySlot.
+     * @param slot the DisplaySlot.
+     * @return the id number.
+     */
+    public static int getId(DisplaySlot slot) {
+        Validate.notNull(slot, "Slot cannot be null");
+        return ids[slot.ordinal()];
+    }
+
+    private static void set(DisplaySlot slot, int id) {
+        ids[slot.ordinal()] = id;
+    }
+
+    static {
+        Arrays.fill(ids, -1);
+        set(PLAYER_LIST, 0);
+        set(SIDEBAR, 1);
+        set(BELOW_NAME, 2);
+    }
+
+}

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -23,6 +23,7 @@ import net.glowstone.net.message.play.game.*;
 import net.glowstone.net.message.play.inv.*;
 import net.glowstone.net.message.play.player.PlayerAbilitiesMessage;
 import net.glowstone.net.protocol.ProtocolType;
+import net.glowstone.scoreboard.GlowScoreboard;
 import net.glowstone.util.StatisticMap;
 import net.glowstone.util.TextWrapper;
 import org.apache.commons.lang.Validate;
@@ -234,6 +235,11 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
     private float walkSpeed = 0.2f;
 
     /**
+     * The scoreboard the player is currently subscribed to.
+     */
+    private GlowScoreboard scoreboard;
+
+    /**
      * Creates a new player and adds it to the world.
      * @param session The player's session.
      * @param profile The player's profile with name and UUID information.
@@ -291,6 +297,9 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         sendTime();
         sendWeather();
         sendAbilities();
+
+        scoreboard = server.getScoreboardManager().getMainScoreboard();
+        scoreboard.subscribe(this);
 
         invMonitor = new InventoryMonitor(getOpenInventory());
         updateInventory(); // send inventory contents
@@ -352,6 +361,10 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         getInventory().removeViewer(this);
         getInventory().getCraftingInventory().removeViewer(this);
         permissions.clearPermissions();
+        if (scoreboard != null) {
+            scoreboard.unsubscribe(this);
+            scoreboard = null;
+        }
         super.remove();
     }
 
@@ -1559,12 +1572,21 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public Scoreboard getScoreboard() {
-        return null;
+        return scoreboard;
     }
 
     @Override
     public void setScoreboard(Scoreboard scoreboard) throws IllegalArgumentException, IllegalStateException {
-
+        Validate.notNull(scoreboard, "Scoreboard must not be null");
+        if (!(scoreboard instanceof GlowScoreboard)) {
+            throw new IllegalArgumentException("Scoreboard must be GlowScoreboard");
+        }
+        if (this.scoreboard == null) {
+            throw new IllegalStateException("Player has not loaded or is already offline");
+        }
+        this.scoreboard.unsubscribe(this);
+        this.scoreboard = (GlowScoreboard) scoreboard;
+        this.scoreboard.subscribe(this);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardDisplayCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardDisplayCodec.java
@@ -1,0 +1,20 @@
+package net.glowstone.net.codec.play.scoreboard;
+
+import com.flowpowered.networking.Codec;
+import com.flowpowered.networking.util.ByteBufUtils;
+import io.netty.buffer.ByteBuf;
+import net.glowstone.net.message.play.scoreboard.ScoreboardDisplayMessage;
+
+import java.io.IOException;
+
+public final class ScoreboardDisplayCodec implements Codec<ScoreboardDisplayMessage> {
+    public ScoreboardDisplayMessage decode(ByteBuf buf) throws IOException {
+        throw new UnsupportedOperationException("Cannot decode ScoreboardDisplayMessage");
+    }
+
+    public ByteBuf encode(ByteBuf buf, ScoreboardDisplayMessage message) throws IOException {
+        buf.writeByte(message.getPosition());
+        ByteBufUtils.writeUTF8(buf, message.getObjective());
+        return buf;
+    }
+}

--- a/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardObjectiveCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardObjectiveCodec.java
@@ -1,0 +1,21 @@
+package net.glowstone.net.codec.play.scoreboard;
+
+import com.flowpowered.networking.Codec;
+import com.flowpowered.networking.util.ByteBufUtils;
+import io.netty.buffer.ByteBuf;
+import net.glowstone.net.message.play.scoreboard.ScoreboardObjectiveMessage;
+
+import java.io.IOException;
+
+public final class ScoreboardObjectiveCodec implements Codec<ScoreboardObjectiveMessage> {
+    public ScoreboardObjectiveMessage decode(ByteBuf buf) throws IOException {
+        throw new UnsupportedOperationException("Cannot decode ScoreboardObjectiveMessage");
+    }
+
+    public ByteBuf encode(ByteBuf buf, ScoreboardObjectiveMessage message) throws IOException {
+        ByteBufUtils.writeUTF8(buf, message.getName());
+        ByteBufUtils.writeUTF8(buf, message.getDisplayName());
+        buf.writeByte(message.getAction());
+        return buf;
+    }
+}

--- a/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardObjectiveCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardObjectiveCodec.java
@@ -2,20 +2,30 @@ package net.glowstone.net.codec.play.scoreboard;
 
 import com.flowpowered.networking.Codec;
 import com.flowpowered.networking.util.ByteBufUtils;
+
 import io.netty.buffer.ByteBuf;
+
 import net.glowstone.net.message.play.scoreboard.ScoreboardObjectiveMessage;
 
 import java.io.IOException;
 
 public final class ScoreboardObjectiveCodec implements Codec<ScoreboardObjectiveMessage> {
+
+    @Override
     public ScoreboardObjectiveMessage decode(ByteBuf buf) throws IOException {
         throw new UnsupportedOperationException("Cannot decode ScoreboardObjectiveMessage");
     }
 
+    @Override
     public ByteBuf encode(ByteBuf buf, ScoreboardObjectiveMessage message) throws IOException {
         ByteBufUtils.writeUTF8(buf, message.getName());
-        ByteBufUtils.writeUTF8(buf, message.getDisplayName());
         buf.writeByte(message.getAction());
+
+        if (message.getAction() == 0 || message.getAction() == 2) {
+            ByteBufUtils.writeUTF8(buf, message.getDisplayName());
+            ByteBufUtils.writeUTF8(buf, message.getType());
+        }
+
         return buf;
     }
 }

--- a/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardScoreCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardScoreCodec.java
@@ -1,0 +1,25 @@
+package net.glowstone.net.codec.play.scoreboard;
+
+import com.flowpowered.networking.Codec;
+import com.flowpowered.networking.util.ByteBufUtils;
+import io.netty.buffer.ByteBuf;
+import net.glowstone.net.message.play.scoreboard.ScoreboardScoreMessage;
+
+import java.io.IOException;
+
+public final class ScoreboardScoreCodec implements Codec<ScoreboardScoreMessage> {
+    public ScoreboardScoreMessage decode(ByteBuf buf) throws IOException {
+        throw new UnsupportedOperationException("Cannot decode ScoreboardScoreMessage");
+    }
+
+    public ByteBuf encode(ByteBuf buf, ScoreboardScoreMessage message) throws IOException {
+        final boolean remove = message.isRemove();
+        ByteBufUtils.writeUTF8(buf, message.getTarget());
+        buf.writeBoolean(remove);
+        if (!remove) {
+            ByteBufUtils.writeUTF8(buf, message.getObjective());
+            buf.writeInt(message.getValue());
+        }
+        return buf;
+    }
+}

--- a/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardScoreCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardScoreCodec.java
@@ -2,7 +2,9 @@ package net.glowstone.net.codec.play.scoreboard;
 
 import com.flowpowered.networking.Codec;
 import com.flowpowered.networking.util.ByteBufUtils;
+
 import io.netty.buffer.ByteBuf;
+
 import net.glowstone.net.message.play.scoreboard.ScoreboardScoreMessage;
 
 import java.io.IOException;
@@ -18,8 +20,9 @@ public final class ScoreboardScoreCodec implements Codec<ScoreboardScoreMessage>
         buf.writeBoolean(remove);
         if (!remove) {
             ByteBufUtils.writeUTF8(buf, message.getObjective());
-            buf.writeInt(message.getValue());
+            ByteBufUtils.writeVarInt(buf, message.getValue());
         }
+
         return buf;
     }
 }

--- a/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardTeamCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardTeamCodec.java
@@ -1,0 +1,42 @@
+package net.glowstone.net.codec.play.scoreboard;
+
+import com.flowpowered.networking.Codec;
+import com.flowpowered.networking.util.ByteBufUtils;
+import io.netty.buffer.ByteBuf;
+import net.glowstone.net.message.play.scoreboard.ScoreboardTeamMessage;
+import net.glowstone.net.message.play.scoreboard.ScoreboardTeamMessage.Action;
+
+import java.io.IOException;
+import java.util.List;
+
+public final class ScoreboardTeamCodec implements Codec<ScoreboardTeamMessage> {
+    public ScoreboardTeamMessage decode(ByteBuf buf) throws IOException {
+        throw new UnsupportedOperationException("Cannot decode ScoreboardTeamMessage");
+    }
+
+    public ByteBuf encode(ByteBuf buf, ScoreboardTeamMessage message) throws IOException {
+        final Action action = message.getAction();
+
+        ByteBufUtils.writeUTF8(buf, message.getTeamName());
+        buf.writeByte(action.ordinal());
+
+        // CREATE and UPDATE
+        if (action == Action.CREATE || action == Action.UPDATE) {
+            ByteBufUtils.writeUTF8(buf, message.getDisplayName());
+            ByteBufUtils.writeUTF8(buf, message.getPrefix());
+            ByteBufUtils.writeUTF8(buf, message.getSuffix());
+            buf.writeByte(message.getFlags());
+        }
+
+        // CREATE, ADD_, and REMOVE_PLAYERS
+        if (action == Action.CREATE || action == Action.ADD_PLAYERS || action == Action.REMOVE_PLAYERS) {
+            final List<String> entries = message.getEntries();
+            buf.writeShort(entries.size());
+            for (String entry : entries) {
+                ByteBufUtils.writeUTF8(buf, entry);
+            }
+        }
+
+        return buf;
+    }
+}

--- a/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardTeamCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/scoreboard/ScoreboardTeamCodec.java
@@ -2,7 +2,9 @@ package net.glowstone.net.codec.play.scoreboard;
 
 import com.flowpowered.networking.Codec;
 import com.flowpowered.networking.util.ByteBufUtils;
+
 import io.netty.buffer.ByteBuf;
+
 import net.glowstone.net.message.play.scoreboard.ScoreboardTeamMessage;
 import net.glowstone.net.message.play.scoreboard.ScoreboardTeamMessage.Action;
 
@@ -10,10 +12,13 @@ import java.io.IOException;
 import java.util.List;
 
 public final class ScoreboardTeamCodec implements Codec<ScoreboardTeamMessage> {
+
+    @Override
     public ScoreboardTeamMessage decode(ByteBuf buf) throws IOException {
         throw new UnsupportedOperationException("Cannot decode ScoreboardTeamMessage");
     }
 
+    @Override
     public ByteBuf encode(ByteBuf buf, ScoreboardTeamMessage message) throws IOException {
         final Action action = message.getAction();
 
@@ -26,12 +31,14 @@ public final class ScoreboardTeamCodec implements Codec<ScoreboardTeamMessage> {
             ByteBufUtils.writeUTF8(buf, message.getPrefix());
             ByteBufUtils.writeUTF8(buf, message.getSuffix());
             buf.writeByte(message.getFlags());
+            ByteBufUtils.writeUTF8(buf, message.getNametagVisibility());
+            buf.writeByte(message.getColor());
         }
 
         // CREATE, ADD_, and REMOVE_PLAYERS
         if (action == Action.CREATE || action == Action.ADD_PLAYERS || action == Action.REMOVE_PLAYERS) {
             final List<String> entries = message.getEntries();
-            buf.writeShort(entries.size());
+            ByteBufUtils.writeVarInt(buf, entries.size());
             for (String entry : entries) {
                 ByteBufUtils.writeUTF8(buf, entry);
             }

--- a/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardDisplayMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardDisplayMessage.java
@@ -19,5 +19,13 @@ public final class ScoreboardDisplayMessage implements Message {
     public String getObjective() {
         return objective;
     }
+
+    @Override
+    public String toString() {
+        return "ScoreboardDisplayMessage{" +
+                "position=" + position +
+                ", objective='" + objective + '\'' +
+                '}';
+    }
 }
 

--- a/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardDisplayMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardDisplayMessage.java
@@ -1,0 +1,23 @@
+package net.glowstone.net.message.play.scoreboard;
+
+import com.flowpowered.networking.Message;
+
+public final class ScoreboardDisplayMessage implements Message {
+
+    private final int position;
+    private final String objective;
+
+    public ScoreboardDisplayMessage(int position, String objective) {
+        this.position = position;
+        this.objective = objective;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public String getObjective() {
+        return objective;
+    }
+}
+

--- a/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardObjectiveMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardObjectiveMessage.java
@@ -8,16 +8,28 @@ public final class ScoreboardObjectiveMessage implements Message {
     private final String displayName;
     private final int action;
 
-    public enum Action {
+    private enum Action {
         CREATE,
         REMOVE,
         UPDATE
     }
 
-    public ScoreboardObjectiveMessage(String name, String displayName, Action action) {
+    private ScoreboardObjectiveMessage(String name, String displayName, Action action) {
         this.name = name;
         this.displayName = displayName;
         this.action = action.ordinal();
+    }
+
+    public static ScoreboardObjectiveMessage create(String name, String displayName) {
+        return new ScoreboardObjectiveMessage(name, displayName, Action.CREATE);
+    }
+
+    public static ScoreboardObjectiveMessage remove(String name, String displayName) {
+        return new ScoreboardObjectiveMessage(name, displayName, Action.REMOVE);
+    }
+
+    public static ScoreboardObjectiveMessage update(String name, String displayName) {
+        return new ScoreboardObjectiveMessage(name, displayName, Action.UPDATE);
     }
 
     public String getName() {
@@ -30,6 +42,15 @@ public final class ScoreboardObjectiveMessage implements Message {
 
     public int getAction() {
         return action;
+    }
+
+    @Override
+    public String toString() {
+        return "ScoreboardObjectiveMessage{" +
+                "name='" + name + '\'' +
+                ", displayName='" + displayName + '\'' +
+                ", action=" + action +
+                '}';
     }
 }
 

--- a/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardObjectiveMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardObjectiveMessage.java
@@ -1,0 +1,35 @@
+package net.glowstone.net.message.play.scoreboard;
+
+import com.flowpowered.networking.Message;
+
+public final class ScoreboardObjectiveMessage implements Message {
+
+    private final String name;
+    private final String displayName;
+    private final int action;
+
+    public enum Action {
+        CREATE,
+        REMOVE,
+        UPDATE
+    }
+
+    public ScoreboardObjectiveMessage(String name, String displayName, Action action) {
+        this.name = name;
+        this.displayName = displayName;
+        this.action = action.ordinal();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public int getAction() {
+        return action;
+    }
+}
+

--- a/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardObjectiveMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardObjectiveMessage.java
@@ -6,6 +6,7 @@ public final class ScoreboardObjectiveMessage implements Message {
 
     private final String name;
     private final String displayName;
+    private final String type;
     private final int action;
 
     private enum Action {
@@ -14,22 +15,23 @@ public final class ScoreboardObjectiveMessage implements Message {
         UPDATE
     }
 
-    private ScoreboardObjectiveMessage(String name, String displayName, Action action) {
+    private ScoreboardObjectiveMessage(String name, String displayName, String type, Action action) {
         this.name = name;
         this.displayName = displayName;
+        this.type = type;
         this.action = action.ordinal();
     }
 
-    public static ScoreboardObjectiveMessage create(String name, String displayName) {
-        return new ScoreboardObjectiveMessage(name, displayName, Action.CREATE);
+    public static ScoreboardObjectiveMessage create(String name, String displayName, String type) {
+        return new ScoreboardObjectiveMessage(name, displayName, type, Action.CREATE);
     }
 
-    public static ScoreboardObjectiveMessage remove(String name, String displayName) {
-        return new ScoreboardObjectiveMessage(name, displayName, Action.REMOVE);
+    public static ScoreboardObjectiveMessage remove(String name) {
+        return new ScoreboardObjectiveMessage(name, null, null, Action.REMOVE);
     }
 
-    public static ScoreboardObjectiveMessage update(String name, String displayName) {
-        return new ScoreboardObjectiveMessage(name, displayName, Action.UPDATE);
+    public static ScoreboardObjectiveMessage update(String name, String displayName, String type) {
+        return new ScoreboardObjectiveMessage(name, displayName, type, Action.UPDATE);
     }
 
     public String getName() {
@@ -38,6 +40,10 @@ public final class ScoreboardObjectiveMessage implements Message {
 
     public String getDisplayName() {
         return displayName;
+    }
+
+    public String getType() {
+        return type;
     }
 
     public int getAction() {
@@ -49,6 +55,7 @@ public final class ScoreboardObjectiveMessage implements Message {
         return "ScoreboardObjectiveMessage{" +
                 "name='" + name + '\'' +
                 ", displayName='" + displayName + '\'' +
+                ", type=" + type + '\'' +
                 ", action=" + action +
                 '}';
     }

--- a/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardScoreMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardScoreMessage.java
@@ -1,0 +1,43 @@
+package net.glowstone.net.message.play.scoreboard;
+
+import com.flowpowered.networking.Message;
+
+public final class ScoreboardScoreMessage implements Message {
+
+    private final String target;
+    private final boolean remove;
+    private final String objective;
+    private final int value;
+
+    private ScoreboardScoreMessage(String target, boolean remove, String objective, int value) {
+        this.target = target;
+        this.remove = remove;
+        this.objective = objective;
+        this.value = value;
+    }
+
+    public ScoreboardScoreMessage(String target, String objective, int value) {
+        this(target, false, objective, value);
+    }
+
+    public static ScoreboardScoreMessage remove(String target) {
+        return new ScoreboardScoreMessage(target, true, null, 0);
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public boolean isRemove() {
+        return remove;
+    }
+
+    public String getObjective() {
+        return objective;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}
+

--- a/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardScoreMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardScoreMessage.java
@@ -39,5 +39,15 @@ public final class ScoreboardScoreMessage implements Message {
     public int getValue() {
         return value;
     }
+
+    @Override
+    public String toString() {
+        return "ScoreboardScoreMessage{" +
+                "target='" + target + '\'' +
+                ", remove=" + remove +
+                ", objective='" + objective + '\'' +
+                ", value=" + value +
+                '}';
+    }
 }
 

--- a/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardTeamMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardTeamMessage.java
@@ -83,5 +83,18 @@ public final class ScoreboardTeamMessage implements Message {
     public List<String> getEntries() {
         return entries;
     }
+
+    @Override
+    public String toString() {
+        return "ScoreboardTeamMessage{" +
+                "teamName='" + teamName + '\'' +
+                ", action=" + action +
+                ", displayName='" + displayName + '\'' +
+                ", prefix='" + prefix + '\'' +
+                ", suffix='" + suffix + '\'' +
+                ", flags=" + flags +
+                ", entries=" + entries +
+                '}';
+    }
 }
 

--- a/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardTeamMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardTeamMessage.java
@@ -1,0 +1,87 @@
+package net.glowstone.net.message.play.scoreboard;
+
+import com.flowpowered.networking.Message;
+
+import java.util.List;
+
+public final class ScoreboardTeamMessage implements Message {
+
+    private final String teamName;
+    private final Action action;
+
+    // CREATE and METADATA only
+    private final String displayName;
+    private final String prefix;
+    private final String suffix;
+    private final int flags;
+
+    // CREATE, ADD_, and REMOVE_PLAYERS only
+    private final List<String> entries;
+
+    public enum Action {
+        CREATE,
+        REMOVE,
+        UPDATE,
+        ADD_PLAYERS,
+        REMOVE_PLAYERS
+    }
+
+    private ScoreboardTeamMessage(String teamName, Action action, String displayName, String prefix, String suffix, boolean friendlyFire, boolean seeInvisible, List<String> entries) {
+        this.teamName = teamName;
+        this.action = action;
+        this.displayName = displayName;
+        this.prefix = prefix;
+        this.suffix = suffix;
+        this.flags = (friendlyFire ? 1 : 0) | (seeInvisible ? 2 : 0);
+        this.entries = entries;
+    }
+
+    public static ScoreboardTeamMessage create(String teamName, String displayName, String prefix, String suffix, boolean friendlyFire, boolean seeInvisible, List<String> players) {
+        return new ScoreboardTeamMessage(teamName, Action.CREATE, displayName, prefix, suffix, friendlyFire, seeInvisible, players);
+    }
+
+    public static ScoreboardTeamMessage remove(String teamName) {
+        return new ScoreboardTeamMessage(teamName, Action.REMOVE, null, null, null, false, false, null);
+    }
+
+    public static ScoreboardTeamMessage update(String teamName, String displayName, String prefix, String suffix, boolean friendlyFire, boolean seeInvisible) {
+        return new ScoreboardTeamMessage(teamName, Action.UPDATE, displayName, prefix, suffix, friendlyFire, seeInvisible, null);
+    }
+
+    public static ScoreboardTeamMessage addPlayers(String teamName, List<String> entries) {
+        return new ScoreboardTeamMessage(teamName, Action.ADD_PLAYERS, null, null, null, false, false, entries);
+    }
+
+    public static ScoreboardTeamMessage removePlayers(String teamName, List<String> entries) {
+        return new ScoreboardTeamMessage(teamName, Action.REMOVE_PLAYERS, null, null, null, false, false, entries);
+    }
+
+    public String getTeamName() {
+        return teamName;
+    }
+
+    public Action getAction() {
+        return action;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String getSuffix() {
+        return suffix;
+    }
+
+    public int getFlags() {
+        return flags;
+    }
+
+    public List<String> getEntries() {
+        return entries;
+    }
+}
+

--- a/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardTeamMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/scoreboard/ScoreboardTeamMessage.java
@@ -14,6 +14,8 @@ public final class ScoreboardTeamMessage implements Message {
     private final String prefix;
     private final String suffix;
     private final int flags;
+    private final String nametagVisibility;
+    private final int color;
 
     // CREATE, ADD_, and REMOVE_PLAYERS only
     private final List<String> entries;
@@ -26,34 +28,36 @@ public final class ScoreboardTeamMessage implements Message {
         REMOVE_PLAYERS
     }
 
-    private ScoreboardTeamMessage(String teamName, Action action, String displayName, String prefix, String suffix, boolean friendlyFire, boolean seeInvisible, List<String> entries) {
+    private ScoreboardTeamMessage(String teamName, Action action, String displayName, String prefix, String suffix, boolean friendlyFire, boolean seeInvisible, String nametagVisibility, int color, List<String> entries) {
         this.teamName = teamName;
         this.action = action;
         this.displayName = displayName;
         this.prefix = prefix;
         this.suffix = suffix;
         this.flags = (friendlyFire ? 1 : 0) | (seeInvisible ? 2 : 0);
+        this.nametagVisibility = nametagVisibility;
+        this.color = color;
         this.entries = entries;
     }
 
-    public static ScoreboardTeamMessage create(String teamName, String displayName, String prefix, String suffix, boolean friendlyFire, boolean seeInvisible, List<String> players) {
-        return new ScoreboardTeamMessage(teamName, Action.CREATE, displayName, prefix, suffix, friendlyFire, seeInvisible, players);
+    public static ScoreboardTeamMessage create(String teamName, String displayName, String prefix, String suffix, boolean friendlyFire, boolean seeInvisible, String nametagVisibility, int color, List<String> players) {
+        return new ScoreboardTeamMessage(teamName, Action.CREATE, displayName, prefix, suffix, friendlyFire, seeInvisible, nametagVisibility, color, players);
     }
 
     public static ScoreboardTeamMessage remove(String teamName) {
-        return new ScoreboardTeamMessage(teamName, Action.REMOVE, null, null, null, false, false, null);
+        return new ScoreboardTeamMessage(teamName, Action.REMOVE, null, null, null, false, false, null, 0, null);
     }
 
-    public static ScoreboardTeamMessage update(String teamName, String displayName, String prefix, String suffix, boolean friendlyFire, boolean seeInvisible) {
-        return new ScoreboardTeamMessage(teamName, Action.UPDATE, displayName, prefix, suffix, friendlyFire, seeInvisible, null);
+    public static ScoreboardTeamMessage update(String teamName, String displayName, String prefix, String suffix, boolean friendlyFire, boolean seeInvisible, String nametagVisibility, int color) {
+        return new ScoreboardTeamMessage(teamName, Action.UPDATE, displayName, prefix, suffix, friendlyFire, seeInvisible, nametagVisibility, color, null);
     }
 
     public static ScoreboardTeamMessage addPlayers(String teamName, List<String> entries) {
-        return new ScoreboardTeamMessage(teamName, Action.ADD_PLAYERS, null, null, null, false, false, entries);
+        return new ScoreboardTeamMessage(teamName, Action.ADD_PLAYERS, null, null, null, false, false, null, 0, entries);
     }
 
     public static ScoreboardTeamMessage removePlayers(String teamName, List<String> entries) {
-        return new ScoreboardTeamMessage(teamName, Action.REMOVE_PLAYERS, null, null, null, false, false, entries);
+        return new ScoreboardTeamMessage(teamName, Action.REMOVE_PLAYERS, null, null, null, false, false, null, 0, entries);
     }
 
     public String getTeamName() {
@@ -80,6 +84,14 @@ public final class ScoreboardTeamMessage implements Message {
         return flags;
     }
 
+    public String getNametagVisibility() {
+        return nametagVisibility;
+    }
+
+    public int getColor() {
+        return color;
+    }
+
     public List<String> getEntries() {
         return entries;
     }
@@ -92,7 +104,9 @@ public final class ScoreboardTeamMessage implements Message {
                 ", displayName='" + displayName + '\'' +
                 ", prefix='" + prefix + '\'' +
                 ", suffix='" + suffix + '\'' +
-                ", flags=" + flags +
+                ", flags=" + flags + '\'' +
+                ", nameTagVisibility='" + nametagVisibility + '\'' +
+                ", color='" + color + '\'' +
                 ", entries=" + entries +
                 '}';
     }

--- a/src/main/java/net/glowstone/net/protocol/PlayProtocol.java
+++ b/src/main/java/net/glowstone/net/protocol/PlayProtocol.java
@@ -6,6 +6,7 @@ import net.glowstone.net.codec.play.entity.*;
 import net.glowstone.net.codec.play.game.*;
 import net.glowstone.net.codec.play.inv.*;
 import net.glowstone.net.codec.play.player.*;
+import net.glowstone.net.codec.play.scoreboard.*;
 import net.glowstone.net.handler.play.game.*;
 import net.glowstone.net.handler.play.inv.*;
 import net.glowstone.net.handler.play.player.*;
@@ -15,6 +16,7 @@ import net.glowstone.net.message.play.entity.*;
 import net.glowstone.net.message.play.game.*;
 import net.glowstone.net.message.play.inv.*;
 import net.glowstone.net.message.play.player.*;
+import net.glowstone.net.message.play.scoreboard.*;
 
 public final class PlayProtocol extends GlowProtocol {
     public PlayProtocol() {
@@ -100,6 +102,10 @@ public final class PlayProtocol extends GlowProtocol {
         outbound(0x38, UserListItemMessage.class, UserListItemCodec.class);
         outbound(0x39, PlayerAbilitiesMessage.class, PlayerAbilitiesCodec.class);
         outbound(0x3A, TabCompleteResponseMessage.class, TabCompleteResponseCodec.class);
+        outbound(0x3B, ScoreboardObjectiveMessage.class, ScoreboardObjectiveCodec.class);
+        outbound(0x3C, ScoreboardScoreMessage.class, ScoreboardScoreCodec.class);
+        outbound(0x3D, ScoreboardDisplayMessage.class, ScoreboardDisplayCodec.class);
+        outbound(0x3E, ScoreboardTeamMessage.class, ScoreboardTeamCodec.class);
         outbound(0x3F, PluginMessage.class, PluginMessageCodec.class);
         outbound(0x40, KickMessage.class, JsonCodec.class);
         outbound(0x46, SetCompressionMessage.class, SetCompressionCodec.class);

--- a/src/main/java/net/glowstone/scoreboard/GlowObjective.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowObjective.java
@@ -1,5 +1,6 @@
 package net.glowstone.scoreboard;
 
+import net.glowstone.net.message.play.scoreboard.ScoreboardObjectiveMessage;
 import org.apache.commons.lang.Validate;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.scoreboard.*;
@@ -19,7 +20,7 @@ public final class GlowObjective implements Objective {
     private final HashMap<String, GlowScore> scores = new HashMap<>();
 
     private String displayName;
-    public DisplaySlot displaySlot;
+    DisplaySlot displaySlot;
 
     public GlowObjective(GlowScoreboard scoreboard, String name, String criteria) {
         this.scoreboard = scoreboard;
@@ -28,7 +29,7 @@ public final class GlowObjective implements Objective {
         displayName = name;
     }
 
-    public Scoreboard getScoreboard() {
+    public GlowScoreboard getScoreboard() {
         return scoreboard;
     }
 
@@ -71,6 +72,7 @@ public final class GlowObjective implements Objective {
         Validate.isTrue(displayName.length() <= 32, "displayName cannot be longer than 32 characters");
 
         this.displayName = displayName;
+        scoreboard.broadcast(ScoreboardObjectiveMessage.update(name, displayName));
     }
 
     public DisplaySlot getDisplaySlot() throws IllegalStateException {
@@ -80,7 +82,14 @@ public final class GlowObjective implements Objective {
 
     public void setDisplaySlot(DisplaySlot slot) throws IllegalStateException {
         checkValid();
-        scoreboard.setDisplaySlot(slot, this);
+        if (slot != displaySlot) {
+            if (displaySlot != null) {
+                scoreboard.setDisplaySlot(displaySlot, null);
+            }
+            if (slot != null) {
+                scoreboard.setDisplaySlot(slot, this);
+            }
+        }
     }
 
     public boolean isModifiable() throws IllegalStateException {

--- a/src/main/java/net/glowstone/scoreboard/GlowObjective.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowObjective.java
@@ -1,0 +1,88 @@
+package net.glowstone.scoreboard;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Score;
+import org.bukkit.scoreboard.Scoreboard;
+
+/**
+ * Scoreboard objective and associated data.
+ */
+public final class GlowObjective implements Objective {
+
+    private GlowScoreboard scoreboard;
+    private final String name;
+    private final String criteria;
+
+    private String displayName;
+    public DisplaySlot displaySlot;
+
+    public GlowObjective(GlowScoreboard scoreboard, String name, String criteria) {
+        this.scoreboard = scoreboard;
+        this.name = name;
+        this.criteria = criteria;
+        displayName = name;
+    }
+
+    public Scoreboard getScoreboard() {
+        return scoreboard;
+    }
+
+    public String getName() throws IllegalStateException {
+        checkValid();
+        return name;
+    }
+
+    public String getCriteria() throws IllegalStateException {
+        checkValid();
+        return criteria;
+    }
+
+    public String getDisplayName() throws IllegalStateException {
+        checkValid();
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) throws IllegalStateException, IllegalArgumentException {
+        checkValid();
+        Validate.notNull(displayName, "displayName cannot be null");
+        Validate.isTrue(displayName.length() <= 32, "displayName cannot be longer than 32 characters");
+
+        this.displayName = displayName;
+    }
+
+    public DisplaySlot getDisplaySlot() throws IllegalStateException {
+        checkValid();
+        return displaySlot;
+    }
+
+    public void setDisplaySlot(DisplaySlot slot) throws IllegalStateException {
+        checkValid();
+        scoreboard.setDisplaySlot(slot, this);
+    }
+
+    public boolean isModifiable() throws IllegalStateException {
+        checkValid();
+        return false;
+    }
+
+    public void unregister() throws IllegalStateException {
+        checkValid();
+        scoreboard.remove(this);
+        scoreboard = null;
+    }
+
+    public Score getScore(OfflinePlayer player) throws IllegalArgumentException, IllegalStateException {
+        checkValid();
+        // todo
+        return null;
+    }
+
+    private void checkValid() {
+        if (scoreboard == null) {
+            throw new IllegalStateException("Cannot manipulate unregistered objective");
+        }
+    }
+}

--- a/src/main/java/net/glowstone/scoreboard/GlowObjective.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowObjective.java
@@ -74,10 +74,15 @@ public final class GlowObjective implements Objective {
         scoreboard = null;
     }
 
-    public Score getScore(OfflinePlayer player) throws IllegalArgumentException, IllegalStateException {
+    public Score getScore(String entry) throws IllegalArgumentException, IllegalStateException {
         checkValid();
         // todo
         return null;
+    }
+
+    @Deprecated
+    public Score getScore(OfflinePlayer player) throws IllegalArgumentException, IllegalStateException {
+        return getScore(player.getName());
     }
 
     private void checkValid() {

--- a/src/main/java/net/glowstone/scoreboard/GlowObjective.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowObjective.java
@@ -2,10 +2,7 @@ package net.glowstone.scoreboard;
 
 import org.apache.commons.lang.Validate;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.scoreboard.DisplaySlot;
-import org.bukkit.scoreboard.Objective;
-import org.bukkit.scoreboard.Score;
-import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,6 +31,24 @@ public final class GlowObjective implements Objective {
     public Scoreboard getScoreboard() {
         return scoreboard;
     }
+
+    public void unregister() throws IllegalStateException {
+        checkValid();
+        for (Map.Entry<String, GlowScore> entry : scores.entrySet()) {
+            scoreboard.getScoresForName(entry.getKey()).remove(entry.getValue());
+        }
+        scoreboard.removeObjective(this);
+        scoreboard = null;
+    }
+
+    void checkValid() {
+        if (scoreboard == null) {
+            throw new IllegalStateException("Cannot manipulate unregistered objective");
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Properties
 
     public String getName() throws IllegalStateException {
         checkValid();
@@ -70,17 +85,11 @@ public final class GlowObjective implements Objective {
 
     public boolean isModifiable() throws IllegalStateException {
         checkValid();
-        return false;
+        return !criteria.equalsIgnoreCase(Criterias.HEALTH);
     }
 
-    public void unregister() throws IllegalStateException {
-        checkValid();
-        scoreboard.remove(this);
-        for (Map.Entry<String, GlowScore> entry : scores.entrySet()) {
-            scoreboard.getScoresForName(entry.getKey()).remove(entry.getValue());
-        }
-        scoreboard = null;
-    }
+    ////////////////////////////////////////////////////////////////////////////
+    // Score management
 
     public Score getScore(String entry) throws IllegalArgumentException, IllegalStateException {
         Validate.notNull(entry, "Entry cannot be null");
@@ -107,11 +116,5 @@ public final class GlowObjective implements Objective {
     public Score getScore(OfflinePlayer player) throws IllegalArgumentException, IllegalStateException {
         Validate.notNull(player, "Player cannot be null");
         return getScore(player.getName());
-    }
-
-    void checkValid() {
-        if (scoreboard == null) {
-            throw new IllegalStateException("Cannot manipulate unregistered objective");
-        }
     }
 }

--- a/src/main/java/net/glowstone/scoreboard/GlowObjective.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowObjective.java
@@ -21,6 +21,7 @@ public final class GlowObjective implements Objective {
 
     private String displayName;
     DisplaySlot displaySlot;
+    private RenderType type = RenderType.INTEGER;
 
     public GlowObjective(GlowScoreboard scoreboard, String name, String criteria) {
         this.scoreboard = scoreboard;
@@ -29,10 +30,12 @@ public final class GlowObjective implements Objective {
         displayName = name;
     }
 
+    @Override
     public GlowScoreboard getScoreboard() {
         return scoreboard;
     }
 
+    @Override
     public void unregister() throws IllegalStateException {
         checkValid();
         for (Map.Entry<String, GlowScore> entry : scores.entrySet()) {
@@ -51,35 +54,41 @@ public final class GlowObjective implements Objective {
     ////////////////////////////////////////////////////////////////////////////
     // Properties
 
+    @Override
     public String getName() throws IllegalStateException {
         checkValid();
         return name;
     }
 
+    @Override
     public String getCriteria() throws IllegalStateException {
         checkValid();
         return criteria;
     }
 
+    @Override
     public String getDisplayName() throws IllegalStateException {
         checkValid();
         return displayName;
     }
 
+    @Override
     public void setDisplayName(String displayName) throws IllegalStateException, IllegalArgumentException {
         checkValid();
         Validate.notNull(displayName, "displayName cannot be null");
         Validate.isTrue(displayName.length() <= 32, "displayName cannot be longer than 32 characters");
 
         this.displayName = displayName;
-        scoreboard.broadcast(ScoreboardObjectiveMessage.update(name, displayName));
+        scoreboard.broadcast(ScoreboardObjectiveMessage.update(name, displayName, type.name().toLowerCase()));
     }
 
+    @Override
     public DisplaySlot getDisplaySlot() throws IllegalStateException {
         checkValid();
         return displaySlot;
     }
 
+    @Override
     public void setDisplaySlot(DisplaySlot slot) throws IllegalStateException {
         checkValid();
         if (slot != displaySlot) {
@@ -92,6 +101,21 @@ public final class GlowObjective implements Objective {
         }
     }
 
+    @Override
+    public RenderType getType() {
+        checkValid();
+        return type;
+    }
+
+    @Override
+    public void setType(RenderType type) {
+        checkValid();
+        Validate.notNull(type, "type cannot be null");
+        this.type = type;
+        scoreboard.broadcast(ScoreboardObjectiveMessage.update(name, displayName, type.name().toLowerCase()));
+    }
+
+    @Override
     public boolean isModifiable() throws IllegalStateException {
         checkValid();
         return !criteria.equalsIgnoreCase(Criterias.HEALTH);
@@ -100,6 +124,7 @@ public final class GlowObjective implements Objective {
     ////////////////////////////////////////////////////////////////////////////
     // Score management
 
+    @Override
     public Score getScore(String entry) throws IllegalArgumentException, IllegalStateException {
         Validate.notNull(entry, "Entry cannot be null");
         checkValid();
@@ -122,6 +147,7 @@ public final class GlowObjective implements Objective {
     }
 
     @Deprecated
+    @Override
     public Score getScore(OfflinePlayer player) throws IllegalArgumentException, IllegalStateException {
         Validate.notNull(player, "Player cannot be null");
         return getScore(player.getName());

--- a/src/main/java/net/glowstone/scoreboard/GlowScore.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowScore.java
@@ -1,5 +1,6 @@
 package net.glowstone.scoreboard;
 
+import net.glowstone.net.message.play.scoreboard.ScoreboardScoreMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.scoreboard.Objective;
@@ -45,5 +46,6 @@ public final class GlowScore implements Score {
     public void setScore(int score) throws IllegalStateException {
         objective.checkValid();
         this.score = score;
+        objective.getScoreboard().broadcast(new ScoreboardScoreMessage(entry, objective.getName(), score));
     }
 }

--- a/src/main/java/net/glowstone/scoreboard/GlowScore.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowScore.java
@@ -1,0 +1,49 @@
+package net.glowstone.scoreboard;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Score;
+import org.bukkit.scoreboard.Scoreboard;
+
+/**
+ * Implementation/data holder for Scores.
+ */
+public class GlowScore implements Score {
+
+    private final GlowObjective objective;
+    private final String entry;
+    private int score;
+
+    public GlowScore(GlowObjective objective, String entry) {
+        this.objective = objective;
+        this.entry = entry;
+    }
+
+    public Objective getObjective() {
+        return objective;
+    }
+
+    public Scoreboard getScoreboard() {
+        return objective.getScoreboard();
+    }
+
+    public String getEntry() {
+        return entry;
+    }
+
+    @Deprecated
+    public OfflinePlayer getPlayer() {
+        return Bukkit.getOfflinePlayer(entry);
+    }
+
+    public int getScore() throws IllegalStateException {
+        objective.checkValid();
+        return score;
+    }
+
+    public void setScore(int score) throws IllegalStateException {
+        objective.checkValid();
+        this.score = score;
+    }
+}

--- a/src/main/java/net/glowstone/scoreboard/GlowScore.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowScore.java
@@ -9,7 +9,7 @@ import org.bukkit.scoreboard.Scoreboard;
 /**
  * Implementation/data holder for Scores.
  */
-public class GlowScore implements Score {
+public final class GlowScore implements Score {
 
     private final GlowObjective objective;
     private final String entry;

--- a/src/main/java/net/glowstone/scoreboard/GlowScoreboard.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowScoreboard.java
@@ -120,18 +120,39 @@ public final class GlowScoreboard implements Scoreboard {
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    // Players/scores
+    // Scores
 
+    public Set<String> getEntries() {
+        return null;
+    }
+
+    public Set<Score> getScores(String entry) throws IllegalArgumentException {
+        Validate.notNull(entry, "Entry cannot be null");
+        return null;
+    }
+
+    public void resetScores(String entry) throws IllegalArgumentException {
+
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // OfflinePlayer methods
+
+    @Deprecated
+    public Set<OfflinePlayer> getPlayers() {
+        // should return Bukkit.getOfflinePlayer(name) for each name in getEntries()
+        return null;
+    }
+
+    @Deprecated
     public Set<Score> getScores(OfflinePlayer player) throws IllegalArgumentException {
         Validate.notNull(player, "Player cannot be null");
-        return null;
+        return getScores(player.getName());
     }
 
+    @Deprecated
     public void resetScores(OfflinePlayer player) throws IllegalArgumentException {
         Validate.notNull(player, "Player cannot be null");
-    }
-
-    public Set<OfflinePlayer> getPlayers() {
-        return null;
+        resetScores(player.getName());
     }
 }

--- a/src/main/java/net/glowstone/scoreboard/GlowScoreboard.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowScoreboard.java
@@ -1,0 +1,77 @@
+package net.glowstone.scoreboard;
+
+import net.glowstone.GlowServer;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.scoreboard.*;
+
+import java.util.Set;
+
+/**
+ * Scoreboard implementation.
+ */
+public class GlowScoreboard implements Scoreboard {
+
+    private final GlowServer server;
+
+    public GlowScoreboard(GlowServer server) {
+        this.server = server;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Objectives
+
+    public Objective registerNewObjective(String name, String criteria) throws IllegalArgumentException {
+        return null;
+    }
+
+    public Objective getObjective(String name) throws IllegalArgumentException {
+        return null;
+    }
+
+    public Set<Objective> getObjectivesByCriteria(String criteria) throws IllegalArgumentException {
+        return null;
+    }
+
+    public Set<Objective> getObjectives() {
+        return null;
+    }
+
+    public Objective getObjective(DisplaySlot slot) throws IllegalArgumentException {
+        return null;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Objectives
+
+    public Set<Score> getScores(OfflinePlayer player) throws IllegalArgumentException {
+        return null;
+    }
+
+    public void resetScores(OfflinePlayer player) throws IllegalArgumentException {
+
+    }
+
+    public Team getPlayerTeam(OfflinePlayer player) throws IllegalArgumentException {
+        return null;
+    }
+
+    public Team getTeam(String teamName) throws IllegalArgumentException {
+        return null;
+    }
+
+    public Set<Team> getTeams() {
+        return null;
+    }
+
+    public Team registerNewTeam(String name) throws IllegalArgumentException {
+        return null;
+    }
+
+    public Set<OfflinePlayer> getPlayers() {
+        return null;
+    }
+
+    public void clearSlot(DisplaySlot slot) throws IllegalArgumentException {
+
+    }
+}

--- a/src/main/java/net/glowstone/scoreboard/GlowScoreboard.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowScoreboard.java
@@ -1,7 +1,14 @@
 package net.glowstone.scoreboard;
 
+import com.flowpowered.networking.Message;
 import com.google.common.collect.ImmutableSet;
 import net.glowstone.GlowServer;
+import net.glowstone.constants.GlowDisplaySlot;
+import net.glowstone.entity.GlowPlayer;
+import net.glowstone.net.message.play.scoreboard.ScoreboardDisplayMessage;
+import net.glowstone.net.message.play.scoreboard.ScoreboardObjectiveMessage;
+import net.glowstone.net.message.play.scoreboard.ScoreboardScoreMessage;
+import net.glowstone.net.message.play.scoreboard.ScoreboardTeamMessage;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -28,6 +35,9 @@ public final class GlowScoreboard implements Scoreboard {
     private final HashMap<String, GlowTeam> teams = new HashMap<>();
     private final HashMap<OfflinePlayer, GlowTeam> playerTeamMap = new HashMap<>();
 
+    // Players who are watching this scoreboard
+    private final HashSet<GlowPlayer> players = new HashSet<>();
+
     public GlowScoreboard(GlowServer server) {
         this.server = server;
     }
@@ -35,18 +45,104 @@ public final class GlowScoreboard implements Scoreboard {
     ////////////////////////////////////////////////////////////////////////////
     // Internals
 
+    /**
+     * Send a player this scoreboard's contents and subscribe them to future
+     * changes.
+     * @param player The player to subscribe.
+     */
+    public void subscribe(GlowPlayer player) {
+        // send all the setup stuff
+        // objectives
+        for (GlowObjective objective : objectives.values()) {
+            player.getSession().send(ScoreboardObjectiveMessage.create(objective.getName(), objective.getDisplayName()));
+        }
+        // display slots
+        for (DisplaySlot slot : DisplaySlot.values()) {
+            GlowObjective objective = displaySlots.get(slot);
+            String name = objective != null ? objective.getName() : "";
+            player.getSession().send(new ScoreboardDisplayMessage(GlowDisplaySlot.getId(slot), name));
+        }
+        // scores
+        for (Map.Entry<String, Set<GlowScore>> entry : scoreMap.entrySet()) {
+            for (GlowScore score : entry.getValue()) {
+                player.getSession().send(new ScoreboardScoreMessage(entry.getKey(), score.getObjective().getName(), score.getScore()));
+            }
+        }
+        // teams
+        for (GlowTeam team : teams.values()) {
+            player.getSession().send(team.getCreateMessage());
+        }
+
+        // add to player set
+        players.add(player);
+    }
+
+    /**
+     * Clear the player's scoreboard contents and unsubscribe them from
+     * future changes.
+     * @param player The player to unsubscribe.
+     */
+    public void unsubscribe(GlowPlayer player) {
+        // remove from player set
+        players.remove(player);
+
+        // send all the teardown stuff
+        // teams
+        for (GlowTeam team : teams.values()) {
+            player.getSession().send(ScoreboardTeamMessage.remove(team.getName()));
+        }
+        // scores
+        for (Map.Entry<String, Set<GlowScore>> entry : scoreMap.entrySet()) {
+            player.getSession().send(ScoreboardScoreMessage.remove(entry.getKey()));
+        }
+        // display slots
+        for (DisplaySlot slot : DisplaySlot.values()) {
+            player.getSession().send(new ScoreboardDisplayMessage(GlowDisplaySlot.getId(slot), ""));
+        }
+        // objectives
+        for (GlowObjective objective : objectives.values()) {
+            player.getSession().send(ScoreboardObjectiveMessage.remove(objective.getName(), objective.getDisplayName()));
+        }
+    }
+
+    /**
+     * Broadcast a scoreboard update to all subscribed players.
+     * @param message The message to send.
+     */
+    void broadcast(Message message) {
+        for (GlowPlayer player : players) {
+            player.getSession().send(message);
+        }
+    }
+
+    /**
+     * Set the objective displayed in the given slot.
+     * @param slot The display slot.
+     * @param objective The objective to display there, possibly null.
+     */
     void setDisplaySlot(DisplaySlot slot, GlowObjective objective) {
         GlowObjective previous = displaySlots.put(slot, objective);
 
+        // previous objective is no longer in this display slot
         if (previous != null) {
             previous.displaySlot = null;
         }
 
+        // new objective is now in this display slot
         if (objective != null) {
+            // update objective's display slot
+            broadcast(new ScoreboardDisplayMessage(GlowDisplaySlot.getId(slot), objective.getName()));
             objective.displaySlot = slot;
+        } else {
+            // no objective
+            broadcast(new ScoreboardDisplayMessage(GlowDisplaySlot.getId(slot), ""));
         }
     }
 
+    /**
+     * Unregister an objective from the scoreboard.
+     * @param objective The objective to unregister.
+     */
     void removeObjective(GlowObjective objective) {
         if (objective.displaySlot != null) {
             setDisplaySlot(objective.displaySlot, null);
@@ -54,15 +150,26 @@ public final class GlowScoreboard implements Scoreboard {
 
         getForCriteria(objective.getCriteria()).remove(objective);
         objectives.remove(objective.getName());
+        broadcast(ScoreboardObjectiveMessage.remove(objective.getName(), objective.getDisplayName()));
     }
 
+    /**
+     * Unregister a team from the scoreboard.
+     * @param team The team to unregister.
+     */
     void removeTeam(GlowTeam team) {
         for (OfflinePlayer player : team.getPlayers()) {
             playerTeamMap.remove(player);
         }
         teams.remove(team.getName());
+        broadcast(ScoreboardTeamMessage.remove(team.getName()));
     }
 
+    /**
+     * Get the internal set of objectives corresponding to a given criteria.
+     * @param criteria The criteria to look up.
+     * @return The set of objectives.
+     */
     Set<GlowObjective> getForCriteria(String criteria) {
         Set<GlowObjective> result = criteriaMap.get(criteria);
         if (result == null) {
@@ -72,6 +179,11 @@ public final class GlowScoreboard implements Scoreboard {
         return result;
     }
 
+    /**
+     * Get the internal set of scores corresponding to a given entry.
+     * @param entry The entry to look up.
+     * @return The set of scores.
+     */
     Set<GlowScore> getScoresForName(String entry) {
         Set<GlowScore> result = scoreMap.get(entry);
         if (result == null) {
@@ -81,10 +193,19 @@ public final class GlowScoreboard implements Scoreboard {
         return result;
     }
 
+    /**
+     * Update what team a player is associated with.
+     * @param player The player.
+     * @param team The team, or null for no team.
+     */
     void setPlayerTeam(OfflinePlayer player, GlowTeam team) {
         GlowTeam previous = playerTeamMap.put(player, team);
         if (previous != null && previous.hasPlayer(player)) {
             previous.rawRemovePlayer(player);
+            broadcast(ScoreboardTeamMessage.removePlayers(previous.getName(), Arrays.asList(player.getName())));
+        }
+        if (team != null) {
+            broadcast(ScoreboardTeamMessage.addPlayers(team.getName(), Arrays.asList(player.getName())));
         }
     }
 
@@ -99,6 +220,8 @@ public final class GlowScoreboard implements Scoreboard {
         GlowObjective objective = new GlowObjective(this, name, criteria);
         objectives.put(name, objective);
         getForCriteria(criteria).add(objective);
+
+        broadcast(ScoreboardObjectiveMessage.create(name, objective.getDisplayName()));
 
         return objective;
     }
@@ -134,6 +257,7 @@ public final class GlowScoreboard implements Scoreboard {
 
         GlowTeam team = new GlowTeam(this, name);
         teams.put(name, team);
+        broadcast(team.getCreateMessage());
         return team;
     }
 
@@ -176,6 +300,7 @@ public final class GlowScoreboard implements Scoreboard {
             objective.deleteScore(entry);
         }
         scoreMap.remove(entry);
+        broadcast(ScoreboardScoreMessage.remove(entry));
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/scoreboard/GlowScoreboard.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowScoreboard.java
@@ -1,61 +1,117 @@
 package net.glowstone.scoreboard;
 
+import com.google.common.collect.ImmutableSet;
 import net.glowstone.GlowServer;
+import org.apache.commons.lang.Validate;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.scoreboard.*;
 
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
  * Scoreboard implementation.
  */
-public class GlowScoreboard implements Scoreboard {
+public final class GlowScoreboard implements Scoreboard {
 
     private final GlowServer server;
+
+    // Objectives
+    private final EnumMap<DisplaySlot, GlowObjective> displaySlots = new EnumMap<>(DisplaySlot.class);
+    private final HashMap<String, GlowObjective> objectives = new HashMap<>();
+    private final HashMap<String, Set<GlowObjective>> criteriaMap = new HashMap<>();
+
+    // Scores
 
     public GlowScoreboard(GlowServer server) {
         this.server = server;
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    // Objectives
+    // Internals
 
-    public Objective registerNewObjective(String name, String criteria) throws IllegalArgumentException {
-        return null;
+    void setDisplaySlot(DisplaySlot slot, GlowObjective objective) {
+        GlowObjective previous = displaySlots.put(slot, objective);
+
+        if (previous != null) {
+            previous.displaySlot = null;
+        }
+
+        if (objective != null) {
+            objective.displaySlot = slot;
+        }
     }
 
-    public Objective getObjective(String name) throws IllegalArgumentException {
-        return null;
+    void remove(GlowObjective objective) {
+        if (objective.displaySlot != null) {
+            setDisplaySlot(objective.displaySlot, null);
+        }
+
+        getForCriteria(objective.getCriteria()).remove(objective);
     }
 
-    public Set<Objective> getObjectivesByCriteria(String criteria) throws IllegalArgumentException {
-        return null;
-    }
-
-    public Set<Objective> getObjectives() {
-        return null;
-    }
-
-    public Objective getObjective(DisplaySlot slot) throws IllegalArgumentException {
-        return null;
+    Set<GlowObjective> getForCriteria(String criteria) {
+        Set<GlowObjective> result = criteriaMap.get(criteria);
+        if (result == null) {
+            result = new HashSet<>();
+            criteriaMap.put(criteria, result);
+        }
+        return result;
     }
 
     ////////////////////////////////////////////////////////////////////////////
     // Objectives
 
-    public Set<Score> getScores(OfflinePlayer player) throws IllegalArgumentException {
+    public Objective registerNewObjective(String name, String criteria) throws IllegalArgumentException {
+        Validate.notNull(name, "Name cannot be null");
+        Validate.notNull(criteria, "Criteria cannot be null");
+        Validate.isTrue(!objectives.containsKey(name), "Objective \"" + name + "\" already exists");
+
+        GlowObjective objective = new GlowObjective(this, name, criteria);
+        objectives.put(name, objective);
+        getForCriteria(criteria).add(objective);
+
+        return objective;
+    }
+
+    public Objective getObjective(String name) throws IllegalArgumentException {
+        return objectives.get(name);
+    }
+
+    public Set<Objective> getObjectivesByCriteria(String criteria) throws IllegalArgumentException {
+        return ImmutableSet.<Objective>copyOf(getForCriteria(criteria));
+    }
+
+    public Set<Objective> getObjectives() {
+        return ImmutableSet.<Objective>copyOf(objectives.values());
+    }
+
+    public Objective getObjective(DisplaySlot slot) throws IllegalArgumentException {
+        Validate.notNull(slot, "Slot cannot be null");
+        return displaySlots.get(slot);
+    }
+
+    public void clearSlot(DisplaySlot slot) throws IllegalArgumentException {
+        Validate.notNull(slot, "Slot cannot be null");
+        setDisplaySlot(slot, null);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Teams
+
+    public Team registerNewTeam(String name) throws IllegalArgumentException {
         return null;
     }
 
-    public void resetScores(OfflinePlayer player) throws IllegalArgumentException {
-
-    }
-
     public Team getPlayerTeam(OfflinePlayer player) throws IllegalArgumentException {
+        Validate.notNull(player, "Player cannot be null");
         return null;
     }
 
     public Team getTeam(String teamName) throws IllegalArgumentException {
+        Validate.notNull(teamName, "Player cannot be null");
         return null;
     }
 
@@ -63,15 +119,19 @@ public class GlowScoreboard implements Scoreboard {
         return null;
     }
 
-    public Team registerNewTeam(String name) throws IllegalArgumentException {
+    ////////////////////////////////////////////////////////////////////////////
+    // Players/scores
+
+    public Set<Score> getScores(OfflinePlayer player) throws IllegalArgumentException {
+        Validate.notNull(player, "Player cannot be null");
         return null;
+    }
+
+    public void resetScores(OfflinePlayer player) throws IllegalArgumentException {
+        Validate.notNull(player, "Player cannot be null");
     }
 
     public Set<OfflinePlayer> getPlayers() {
         return null;
-    }
-
-    public void clearSlot(DisplaySlot slot) throws IllegalArgumentException {
-
     }
 }

--- a/src/main/java/net/glowstone/scoreboard/GlowScoreboard.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowScoreboard.java
@@ -54,7 +54,7 @@ public final class GlowScoreboard implements Scoreboard {
         // send all the setup stuff
         // objectives
         for (GlowObjective objective : objectives.values()) {
-            player.getSession().send(ScoreboardObjectiveMessage.create(objective.getName(), objective.getDisplayName()));
+            player.getSession().send(ScoreboardObjectiveMessage.create(objective.getName(), objective.getDisplayName(), objective.getType().name().toLowerCase()));
         }
         // display slots
         for (DisplaySlot slot : DisplaySlot.values()) {
@@ -101,7 +101,7 @@ public final class GlowScoreboard implements Scoreboard {
         }
         // objectives
         for (GlowObjective objective : objectives.values()) {
-            player.getSession().send(ScoreboardObjectiveMessage.remove(objective.getName(), objective.getDisplayName()));
+            player.getSession().send(ScoreboardObjectiveMessage.remove(objective.getName()));
         }
     }
 
@@ -150,7 +150,7 @@ public final class GlowScoreboard implements Scoreboard {
 
         getForCriteria(objective.getCriteria()).remove(objective);
         objectives.remove(objective.getName());
-        broadcast(ScoreboardObjectiveMessage.remove(objective.getName(), objective.getDisplayName()));
+        broadcast(ScoreboardObjectiveMessage.remove(objective.getName()));
     }
 
     /**
@@ -221,7 +221,7 @@ public final class GlowScoreboard implements Scoreboard {
         objectives.put(name, objective);
         getForCriteria(criteria).add(objective);
 
-        broadcast(ScoreboardObjectiveMessage.create(name, objective.getDisplayName()));
+        broadcast(ScoreboardObjectiveMessage.create(name, objective.getDisplayName(), objective.getType().name().toLowerCase()));
 
         return objective;
     }

--- a/src/main/java/net/glowstone/scoreboard/GlowScoreboardManager.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowScoreboardManager.java
@@ -7,7 +7,7 @@ import org.bukkit.scoreboard.ScoreboardManager;
 /**
  * ScoreboardManager implementation.
  */
-public class GlowScoreboardManager implements ScoreboardManager {
+public final class GlowScoreboardManager implements ScoreboardManager {
 
     private final GlowScoreboard mainScoreboard;
     private final GlowServer server;

--- a/src/main/java/net/glowstone/scoreboard/GlowScoreboardManager.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowScoreboardManager.java
@@ -1,0 +1,27 @@
+package net.glowstone.scoreboard;
+
+import net.glowstone.GlowServer;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.ScoreboardManager;
+
+/**
+ * ScoreboardManager implementation.
+ */
+public class GlowScoreboardManager implements ScoreboardManager {
+
+    private final GlowScoreboard mainScoreboard;
+    private final GlowServer server;
+
+    public GlowScoreboardManager(GlowServer server) {
+        this.server = server;
+        mainScoreboard = new GlowScoreboard(server);
+    }
+
+    public Scoreboard getMainScoreboard() {
+        return mainScoreboard;
+    }
+
+    public Scoreboard getNewScoreboard() {
+        return new GlowScoreboard(server);
+    }
+}

--- a/src/main/java/net/glowstone/scoreboard/GlowScoreboardManager.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowScoreboardManager.java
@@ -1,7 +1,6 @@
 package net.glowstone.scoreboard;
 
 import net.glowstone.GlowServer;
-import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.ScoreboardManager;
 
 /**
@@ -17,11 +16,11 @@ public final class GlowScoreboardManager implements ScoreboardManager {
         mainScoreboard = new GlowScoreboard(server);
     }
 
-    public Scoreboard getMainScoreboard() {
+    public GlowScoreboard getMainScoreboard() {
         return mainScoreboard;
     }
 
-    public Scoreboard getNewScoreboard() {
+    public GlowScoreboard getNewScoreboard() {
         return new GlowScoreboard(server);
     }
 }

--- a/src/main/java/net/glowstone/scoreboard/GlowTeam.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowTeam.java
@@ -1,0 +1,155 @@
+package net.glowstone.scoreboard;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang.Validate;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.Team;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Implementation for scoreboard teams.
+ */
+public final class GlowTeam implements Team {
+
+    private GlowScoreboard scoreboard;
+    private final String name;
+
+    private final HashSet<OfflinePlayer> players = new HashSet<>();
+
+    // properties
+    private String displayName;
+    private String prefix = "";
+    private String suffix = "";
+    private boolean friendlyFire = false;
+    private boolean seeInvisible = true;
+
+    public GlowTeam(GlowScoreboard scoreboard, String name) {
+        this.scoreboard = scoreboard;
+        this.name = name;
+        displayName = name;
+    }
+
+    public Scoreboard getScoreboard() {
+        return scoreboard;
+    }
+
+    public void unregister() throws IllegalStateException {
+        checkValid();
+        scoreboard.removeTeam(this);
+        scoreboard = null;
+    }
+
+    void checkValid() {
+        if (scoreboard == null) {
+            throw new IllegalStateException("Cannot manipulate unregistered team");
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Properties
+
+    public String getName() throws IllegalStateException {
+        checkValid();
+        return name;
+    }
+
+    public String getDisplayName() throws IllegalStateException {
+        checkValid();
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) throws IllegalStateException, IllegalArgumentException {
+        Validate.notNull(displayName, "Display name cannot be null");
+        checkValid();
+        this.displayName = displayName;
+    }
+
+    public String getPrefix() throws IllegalStateException {
+        checkValid();
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) throws IllegalStateException, IllegalArgumentException {
+        Validate.notNull(prefix, "Prefix cannot be null");
+        checkValid();
+        this.prefix = prefix;
+    }
+
+    public String getSuffix() throws IllegalStateException {
+        checkValid();
+        return suffix;
+    }
+
+    public void setSuffix(String suffix) throws IllegalStateException, IllegalArgumentException {
+        Validate.notNull(suffix, "Suffix cannot be null");
+        checkValid();
+        this.suffix = suffix;
+    }
+
+    public boolean allowFriendlyFire() throws IllegalStateException {
+        checkValid();
+        return friendlyFire;
+    }
+
+    public void setAllowFriendlyFire(boolean enabled) throws IllegalStateException {
+        checkValid();
+        friendlyFire = enabled;
+    }
+
+    public boolean canSeeFriendlyInvisibles() throws IllegalStateException {
+        checkValid();
+        return seeInvisible;
+    }
+
+    public void setCanSeeFriendlyInvisibles(boolean enabled) throws IllegalStateException {
+        checkValid();
+        seeInvisible = enabled;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Player management
+
+    public Set<OfflinePlayer> getPlayers() throws IllegalStateException {
+        checkValid();
+        return ImmutableSet.copyOf(players);
+    }
+
+    public int getSize() throws IllegalStateException {
+        checkValid();
+        return players.size();
+    }
+
+    public void addPlayer(OfflinePlayer player) throws IllegalStateException, IllegalArgumentException {
+        Validate.notNull(player, "Player cannot be null");
+        checkValid();
+        players.add(player);
+        scoreboard.setPlayerTeam(player, this);
+    }
+
+    public boolean removePlayer(OfflinePlayer player) throws IllegalStateException, IllegalArgumentException {
+        Validate.notNull(player, "Player cannot be null");
+        checkValid();
+        if (players.remove(player)) {
+            scoreboard.setPlayerTeam(player, null);
+            return true;
+        }
+        return false;
+    }
+
+    public boolean hasPlayer(OfflinePlayer player) throws IllegalArgumentException, IllegalStateException {
+        Validate.notNull(player, "Player cannot be null");
+        checkValid();
+        return players.contains(player);
+    }
+
+    /**
+     * Remove a player without propagating the change to the scoreboard.
+     * @param player The player to remove.
+     */
+    void rawRemovePlayer(OfflinePlayer player) {
+        players.remove(player);
+    }
+}

--- a/src/main/java/net/glowstone/scoreboard/GlowTeam.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowTeam.java
@@ -1,12 +1,16 @@
 package net.glowstone.scoreboard;
 
+import com.flowpowered.networking.Message;
 import com.google.common.collect.ImmutableSet;
+import net.glowstone.net.message.play.scoreboard.ScoreboardTeamMessage;
 import org.apache.commons.lang.Validate;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -48,6 +52,18 @@ public final class GlowTeam implements Team {
         }
     }
 
+    Message getCreateMessage() {
+        List<String> playerNames = new ArrayList<>(players.size());
+        for (OfflinePlayer player : players) {
+            playerNames.add(player.getName());
+        }
+        return ScoreboardTeamMessage.create(name, displayName, prefix, suffix, friendlyFire, seeInvisible, playerNames);
+    }
+
+    private void update() {
+        scoreboard.broadcast(ScoreboardTeamMessage.update(name, displayName, prefix, suffix, friendlyFire, seeInvisible));
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Properties
 
@@ -65,6 +81,7 @@ public final class GlowTeam implements Team {
         Validate.notNull(displayName, "Display name cannot be null");
         checkValid();
         this.displayName = displayName;
+        update();
     }
 
     public String getPrefix() throws IllegalStateException {
@@ -76,6 +93,7 @@ public final class GlowTeam implements Team {
         Validate.notNull(prefix, "Prefix cannot be null");
         checkValid();
         this.prefix = prefix;
+        update();
     }
 
     public String getSuffix() throws IllegalStateException {
@@ -87,6 +105,7 @@ public final class GlowTeam implements Team {
         Validate.notNull(suffix, "Suffix cannot be null");
         checkValid();
         this.suffix = suffix;
+        update();
     }
 
     public boolean allowFriendlyFire() throws IllegalStateException {
@@ -97,6 +116,7 @@ public final class GlowTeam implements Team {
     public void setAllowFriendlyFire(boolean enabled) throws IllegalStateException {
         checkValid();
         friendlyFire = enabled;
+        update();
     }
 
     public boolean canSeeFriendlyInvisibles() throws IllegalStateException {
@@ -107,6 +127,7 @@ public final class GlowTeam implements Team {
     public void setCanSeeFriendlyInvisibles(boolean enabled) throws IllegalStateException {
         checkValid();
         seeInvisible = enabled;
+        update();
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/scoreboard/GlowTeam.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowTeam.java
@@ -1,17 +1,22 @@
 package net.glowstone.scoreboard;
 
 import com.flowpowered.networking.Message;
+import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableSet;
-import net.glowstone.net.message.play.scoreboard.ScoreboardTeamMessage;
-import org.apache.commons.lang.Validate;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.scoreboard.Scoreboard;
-import org.bukkit.scoreboard.Team;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import net.glowstone.net.message.play.scoreboard.ScoreboardTeamMessage;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.scoreboard.NametagVisibility;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.Team;
 
 /**
  * Implementation for scoreboard teams.
@@ -29,6 +34,8 @@ public final class GlowTeam implements Team {
     private String suffix = "";
     private boolean friendlyFire = false;
     private boolean seeInvisible = true;
+    private NametagVisibility nametagVisibility = NametagVisibility.ALWAYS;
+    private ChatColor color = ChatColor.RESET;
 
     public GlowTeam(GlowScoreboard scoreboard, String name) {
         this.scoreboard = scoreboard;
@@ -36,10 +43,12 @@ public final class GlowTeam implements Team {
         displayName = name;
     }
 
+    @Override
     public Scoreboard getScoreboard() {
         return scoreboard;
     }
 
+    @Override
     public void unregister() throws IllegalStateException {
         checkValid();
         scoreboard.removeTeam(this);
@@ -57,26 +66,32 @@ public final class GlowTeam implements Team {
         for (OfflinePlayer player : players) {
             playerNames.add(player.getName());
         }
-        return ScoreboardTeamMessage.create(name, displayName, prefix, suffix, friendlyFire, seeInvisible, playerNames);
+        
+        return ScoreboardTeamMessage.create(name, displayName, prefix, suffix, friendlyFire, seeInvisible
+                , CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, nametagVisibility.name()), color.isColor() ? color.ordinal() : -1, playerNames);
     }
 
     private void update() {
-        scoreboard.broadcast(ScoreboardTeamMessage.update(name, displayName, prefix, suffix, friendlyFire, seeInvisible));
+        scoreboard.broadcast(ScoreboardTeamMessage.update(name, displayName, prefix, suffix, friendlyFire, seeInvisible
+                , CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, nametagVisibility.name()), color.isColor() ? color.ordinal() : -1));
     }
 
     ////////////////////////////////////////////////////////////////////////////
     // Properties
 
+    @Override
     public String getName() throws IllegalStateException {
         checkValid();
         return name;
     }
 
+    @Override
     public String getDisplayName() throws IllegalStateException {
         checkValid();
         return displayName;
     }
 
+    @Override
     public void setDisplayName(String displayName) throws IllegalStateException, IllegalArgumentException {
         Validate.notNull(displayName, "Display name cannot be null");
         checkValid();
@@ -84,11 +99,13 @@ public final class GlowTeam implements Team {
         update();
     }
 
+    @Override
     public String getPrefix() throws IllegalStateException {
         checkValid();
         return prefix;
     }
 
+    @Override
     public void setPrefix(String prefix) throws IllegalStateException, IllegalArgumentException {
         Validate.notNull(prefix, "Prefix cannot be null");
         checkValid();
@@ -96,11 +113,13 @@ public final class GlowTeam implements Team {
         update();
     }
 
+    @Override
     public String getSuffix() throws IllegalStateException {
         checkValid();
         return suffix;
     }
 
+    @Override
     public void setSuffix(String suffix) throws IllegalStateException, IllegalArgumentException {
         Validate.notNull(suffix, "Suffix cannot be null");
         checkValid();
@@ -108,41 +127,74 @@ public final class GlowTeam implements Team {
         update();
     }
 
+    @Override
     public boolean allowFriendlyFire() throws IllegalStateException {
         checkValid();
         return friendlyFire;
     }
 
+    @Override
     public void setAllowFriendlyFire(boolean enabled) throws IllegalStateException {
         checkValid();
         friendlyFire = enabled;
         update();
     }
 
+    @Override
     public boolean canSeeFriendlyInvisibles() throws IllegalStateException {
         checkValid();
         return seeInvisible;
     }
 
+    @Override
     public void setCanSeeFriendlyInvisibles(boolean enabled) throws IllegalStateException {
         checkValid();
         seeInvisible = enabled;
         update();
     }
 
+    @Override
+    public NametagVisibility getNametagVisibility() {
+        return nametagVisibility;
+    }
+
+    @Override
+    public void setNametagVisibility(NametagVisibility visibility) {
+        Validate.notNull(visibility, "Visibility cannot be null");
+        nametagVisibility = visibility;
+        update();
+    }
+
+    @Override
+    public ChatColor getColor() {
+        return color;
+    }
+
+    @Override
+    public void setColor(ChatColor color) {
+        checkValid();
+        Validate.notNull(color, "Color cannot be null");
+        Validate.isTrue(!color.isFormat() , "Color must be either a color or RESET");
+        this.color = color;
+        update();
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Player management
 
+    @Override
     public Set<OfflinePlayer> getPlayers() throws IllegalStateException {
         checkValid();
         return ImmutableSet.copyOf(players);
     }
 
+    @Override
     public int getSize() throws IllegalStateException {
         checkValid();
         return players.size();
     }
 
+    @Override
     public void addPlayer(OfflinePlayer player) throws IllegalStateException, IllegalArgumentException {
         Validate.notNull(player, "Player cannot be null");
         checkValid();
@@ -150,6 +202,7 @@ public final class GlowTeam implements Team {
         scoreboard.setPlayerTeam(player, this);
     }
 
+    @Override
     public boolean removePlayer(OfflinePlayer player) throws IllegalStateException, IllegalArgumentException {
         Validate.notNull(player, "Player cannot be null");
         checkValid();
@@ -160,6 +213,7 @@ public final class GlowTeam implements Team {
         return false;
     }
 
+    @Override
     public boolean hasPlayer(OfflinePlayer player) throws IllegalArgumentException, IllegalStateException {
         Validate.notNull(player, "Player cannot be null");
         checkValid();

--- a/src/test/java/net/glowstone/constants/DisplaySlotTest.java
+++ b/src/test/java/net/glowstone/constants/DisplaySlotTest.java
@@ -1,0 +1,20 @@
+package net.glowstone.constants;
+
+import org.bukkit.scoreboard.DisplaySlot;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the {@link GlowDisplaySlot} class.
+ */
+public class DisplaySlotTest {
+
+    @Test
+    public void testAllValues() {
+        for (DisplaySlot slot : DisplaySlot.values()) {
+            assertTrue("ID missing for display slot " + slot, GlowDisplaySlot.getId(slot) >= 0);
+        }
+    }
+
+}


### PR DESCRIPTION
Update the scoreboard api for 1.8 clients. Based on the scoreboard branch from @SpaceManiac . 
The color feature from the scoreboard teams isn't complete implemented yet. In my opinion it needs some discussion what's the best way is to implement it.
So it's also not fully tested, but all possible values that will be sent are valid. (Chat color codes or -1 as reset)
All other implemented things are minor tested.

Changes:
- Add missing codecs and so missing features
- Add missing Override annoations
- Change a couple of integer values to VarInt
- Fix missing order of some packet values

Testing material:
- Source: https://gist.github.com/games647/8dd1fba7695c8553228a
- File: https://www.dropbox.com/s/j7jfs3yezknbrlp/ScoreboardTest.jar
- Just for testing propose.
- Example command: /test team xyz register

Related GlowKit ticket https://github.com/GlowstoneMC/GlowKit/pull/16
Related to #81 

ToDo: 
- Implement missing display slots.
- Make a complete rebase after review?

Questions:
Should [this](https://github.com/games647/Glowstone/blob/scoreboard1.8/src/main/java/net/glowstone/scoreboard/GlowTeam.java#L71) be done by a method, enum value or is this okay?
[Enum, boolean or String](https://github.com/games647/Glowstone/blob/scoreboard1.8/src/main/java/net/glowstone/scoreboard/GlowObjective.java#L111)? (It's currently implemented as enum on vanilla servers, so they may add more)
Should update packets only be sent on changes? 
