### PR TITLE
Config option to turn off spawn chunk persistance

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1289,6 +1289,10 @@ public final class GlowServer implements Server {
     public String getWorldType() {
         return config.getString(ServerConfig.Key.LEVEL_TYPE);
     }
+    
+    public boolean keepSpawnChunks() {
+    return config.getBoolean(ServerConfig.Key.PERSIST_SPAWN);
+    }
 
     @Override
     public boolean getGenerateStructures() {

--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -238,6 +238,7 @@ public final class GlowWorld implements World {
         animalLimit = server.getAnimalSpawnLimit();
         waterAnimalLimit = server.getWaterAnimalSpawnLimit();
         ambientLimit = server.getAmbientSpawnLimit();
+        keepSpawnLoaded = server.keepSpawnChunks();
 
         // read in world data
         WorldFinalValues values = null;

--- a/src/main/java/net/glowstone/util/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/ServerConfig.java
@@ -309,6 +309,7 @@ public final class ServerConfig {
         GENERATOR_SETTINGS("world.gen-settings", "", Migrate.PROPS, "generator-settings"),
         ALLOW_NETHER("world.allow-nether", true, Migrate.PROPS, "allow-nether"),
         ALLOW_END("world.allow-end", true, Migrate.BUKKIT, "settings.allow-end"),
+        PERSIST_SPAWN("world.keep-spawn-loaded", true),
 
         // game props
         GAMEMODE("game.gamemode", "SURVIVAL", Migrate.PROPS, "gamemode"),


### PR DESCRIPTION
This commit will give the option to turn off keeping spawn loaded in the config.
world:
keep-spawn-loaded: false

That would not persist any spawn chunks. It is true by default, though.
resubmitted from #233 due to merge conflicts.
