### PR TITLE
Move code for block rotation out of BlockSign

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockSign.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSign.java
@@ -6,20 +6,16 @@ import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.TESign;
 import net.glowstone.block.entity.TileEntity;
 import net.glowstone.entity.GlowPlayer;
-import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.material.Sign;
 import org.bukkit.util.Vector;
 
 public class BlockSign extends BlockType {
 
     public BlockSign() {
         setDrops(new ItemStack(Material.SIGN));
-    }
-
-    public boolean isWallSign() {
-        return getMaterial() == Material.WALL_SIGN;
     }
 
     @Override
@@ -30,36 +26,16 @@ public class BlockSign extends BlockType {
     @Override
     public void placeBlock(GlowPlayer player, GlowBlockState state, BlockFace face, ItemStack holding, Vector clickedLoc) {
         state.setType(getMaterial());
-        byte data;
-        if (isWallSign()) {
-            // attach to appropriate side of wall
-            data = getFacing(face);
-        } else {
-            // calculate the facing of the sign based on the angle between the player and the post
-            Location loc = player.getLocation();
-            // 22.5 = 360 / 16
-            long facing = Math.round(loc.getYaw() / 22.5) + 8;
-            data = (byte) (((facing % 16) + 16) % 16);
+        if (!(state.getData() instanceof Sign)) {
+            warnMaterialData(Sign.class, state.getData());
+            return;
         }
-        state.setRawData(data);
+        Sign sign = (Sign) state.getData();
+        sign.setFacingDirection(sign.isWallSign() ? face : player.getFacing().getOppositeFace());
     }
 
     @Override
     public void afterPlace(GlowPlayer player, GlowBlock block, ItemStack holding) {
         player.openSignEditor(block.getLocation());
-    }
-
-    private byte getFacing(BlockFace face) {
-        switch (face) {
-            case NORTH:
-                return 2;
-            case SOUTH:
-                return 3;
-            case WEST:
-                return 4;
-            case EAST:
-                return 5;
-        }
-        return 0;
     }
 }

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -216,6 +216,15 @@ public abstract class GlowEntity implements Entity {
         }
     }
 
+    /**
+     * Gets the full direction (including SOUTH_SOUTH_EAST etc) this entity is facing.
+     * @return The intercardinal BlockFace of this entity
+     */
+    public BlockFace getFacing() {
+        long facing = Math.round(getLocation().getYaw() / 22.5) + 8;
+        return Position.getDirection((byte) (facing % 16));
+    }
+
     @Override
     public void setVelocity(Vector velocity) {
         this.velocity.copy(velocity);

--- a/src/main/java/net/glowstone/util/Position.java
+++ b/src/main/java/net/glowstone/util/Position.java
@@ -1,6 +1,12 @@
 package net.glowstone.util;
 
+import com.google.common.collect.ImmutableList;
 import org.bukkit.Location;
+import org.bukkit.block.BlockFace;
+
+import java.util.List;
+
+import static org.bukkit.block.BlockFace.*;
 
 /**
  * A static class housing position-related utilities and constants.
@@ -16,6 +22,14 @@ public final class Position {
      * {@code 1.5 * 32 = 48} within certain packets.
      */
     public static final int GRANULARITY = 32;
+
+    /**
+     * Common Rotation values used blocks such as Signs, Skulls, and Banners.
+     * The order relates to the data/tag that is applied to the block on placing.
+     */
+    public static final List<BlockFace> ROTATIONS = ImmutableList.of(NORTH, NORTH_NORTH_EAST, NORTH_EAST,
+            EAST_NORTH_EAST, EAST, EAST_SOUTH_EAST, SOUTH_EAST, SOUTH_SOUTH_EAST, SOUTH, SOUTH_SOUTH_WEST,
+            SOUTH_WEST, WEST_SOUTH_WEST, WEST, WEST_NORTH_WEST, NORTH_WEST, NORTH_NORTH_WEST);
 
     /**
      * Gets the X coordinate multiplied the granularity and rounded to an
@@ -93,6 +107,25 @@ public final class Position {
         dest.setPitch(source.getPitch());
         dest.setYaw(source.getYaw());
         return dest;
+    }
+
+    /**
+     * Get an intercardinal BlockFace from a rotation value, where NORTH is 0.
+     * @param rotation byte value rotation to get
+     * @return intercardinal BlockFace
+     * @throws IndexOutOfBoundsException If 0 > value > 15
+     */
+    public static BlockFace getDirection(byte rotation) {
+        return ROTATIONS.get(rotation);
+    }
+
+    /**
+     * Gets the byte rotation for an intercardinal BlockFace, where NORTH is 0.
+     * @param rotation Rotation to get
+     * @return byte data value for the given rotation, or -1 if rotation is SELF or null
+     */
+    public static byte getDirection(BlockFace rotation) {
+        return (byte) ROTATIONS.indexOf(rotation);
     }
 
 }


### PR DESCRIPTION
This generifies the rotation code in BlockSign, as it is also used for banners and skulls.

Three changes:
- Changes BlockSign to use the Bukkit API to set its rotation, rather than setting the raw data directly.
- Add method to GlowEntity to get its full, intercardinal (eg north north east) direction in BlockFace.
- Add method to Position Util to convert between BlockFace and byte data value (common between rotatables)
