### PR TITLE
Handle invalid arguments with a warning only

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -106,9 +106,8 @@ public final class GlowServer implements Server {
             final String opt = args[i];
 
             if (!opt.startsWith("-")) {
-                System.err.println("Invalid Option: " + opt);
-                System.exit(1);
-                return null;
+                System.err.println("Ignored invalid Option: " + opt);
+                continue;
             }
 
             // Help
@@ -134,9 +133,8 @@ public final class GlowServer implements Server {
 
             // Below this point, options require parameters
             if (i == args.length - 1) {
-                System.err.println("Option specified without value: " + opt);
-                System.exit(1);
-                return null;
+                System.err.println("Ignored option specified without value: " + opt);
+                continue;
             }
 
             if ("--configdir".equals(opt)) {
@@ -164,9 +162,7 @@ public final class GlowServer implements Server {
                 continue;
             }
 
-            System.err.println("Unknown option: " + opt);
-            System.exit(1);
-            return null;
+            System.err.println("Ignored unknown option: " + opt);
         }
 
         final File configDir = new File(configDirName);


### PR DESCRIPTION
This commit changes the server startup code so that it doesn't fail if it encounters an invalid argument.
This change is motivated by the fact that most server hosts provide the nogui option in their startup script and would thus prevent the glowstone servers from starting.
