### PR TITLE
Add Eclipse and IDEA plugins to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@ apply plugin: 'project-report' // Adds project report tasks
 apply plugin: 'com.github.johnrengelman.shadow' // Provides dependency shading
 apply plugin: 'net.glowstone.remapper' // Provides method remapping
 apply plugin: 'checkstyle' // Checks code style
+apply plugin: 'eclipse' // Provides elipse project tasks
+apply plugin: 'idea' // Provides idea project tasks
 apply from: 'etc/publish.gradle'
 
 // Methods to determine detailed version string

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'glowstone'
+rootProject.name = 'Glowstone'


### PR DESCRIPTION
This will provide a few tasks to gradle for building project files for both IDE.
Those who wish to import an Eclipse project will do:
./gradlew eclipse
Those who wish to import an IDEA project will do:
./gradlew idea
