### PR TITLE
Double chests

### DIFF
--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -43,7 +43,8 @@ public final class ItemTable {
         reg(Material.WALL_SIGN, new BlockSign());
         reg(Material.WORKBENCH, new BlockWorkbench());
         reg(Material.ENDER_CHEST, new BlockEnderchest());
-        reg(Material.CHEST, new BlockChest());
+        reg(Material.CHEST, new BlockChest(false));
+        reg(Material.TRAPPED_CHEST, new BlockChest(true));
         reg(Material.DISPENSER, new BlockDispenser());
         reg(Material.DROPPER, new BlockDropper());
         reg(Material.BOOKSHELF, new BlockDirectDrops(Material.BOOK, 3));

--- a/src/main/java/net/glowstone/block/blocktype/BlockChest.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockChest.java
@@ -1,21 +1,59 @@
 package net.glowstone.block.blocktype;
 
 import net.glowstone.GlowChunk;
+import net.glowstone.GlowServer;
+import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.TEChest;
 import net.glowstone.block.entity.TileEntity;
 import net.glowstone.entity.GlowPlayer;
+import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.Chest;
 import org.bukkit.material.MaterialData;
 import org.bukkit.util.Vector;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 public class BlockChest extends BlockContainer {
+
+    private final boolean isTrapped;
+
+    public BlockChest(boolean isTrapped) {
+        this.isTrapped = isTrapped;
+    }
 
     @Override
     public TileEntity createTileEntity(GlowChunk chunk, int cx, int cy, int cz) {
         return new TEChest(chunk.getBlock(cx, cy, cz));
+    }
+
+    @Override
+    public boolean blockInteract(GlowPlayer player, GlowBlock block, BlockFace face, Vector clickedLoc) {
+        BlockState state = block.getState();
+        if (state instanceof org.bukkit.block.Chest) {
+            org.bukkit.block.Chest chest = (org.bukkit.block.Chest) state;
+            //todo animation etc.
+            player.openInventory(chest.getInventory());
+            return true;
+        }
+
+        GlowServer.logger.warning("Calling blockInteract on BlockChest, but BlockState is " + state);
+
+        return false;
+    }
+
+    @Override
+    public boolean canPlaceAt(GlowBlock block, BlockFace against) {
+        Collection<BlockFace> nearChests = searchChests(block);
+        if (nearChests.size() > 1) {
+            return false;
+        }
+
+        return true;
     }
 
     @Override
@@ -24,10 +62,96 @@ public class BlockChest extends BlockContainer {
 
         MaterialData data = state.getData();
         if (data instanceof Chest) {
-            ((Chest) data).setFacingDirection(getOppositeBlockFace(player.getLocation(), false));
-            state.setData(data);
+            Chest chest = (Chest) data;
+            GlowBlock chestBlock = state.getBlock();
+
+            BlockFace normalFacing = getOppositeBlockFace(player.getLocation(), false);
+
+            Collection<BlockFace> attachedChests = searchChests(chestBlock);
+            if (attachedChests.isEmpty()) {
+                chest.setFacingDirection(normalFacing);
+                state.setData(chest);
+                return;
+            } else if (attachedChests.size() > 1) {
+                GlowServer.logger.warning("Chest placed near two other chests!");
+                return;
+            }
+
+            BlockFace otherPart = attachedChests.iterator().next();
+
+            GlowBlock otherPartBlock = chestBlock.getRelative(otherPart);
+            BlockState otherPartState = otherPartBlock.getState();
+            MaterialData otherPartData = otherPartState.getData();
+
+            if (otherPartData instanceof Chest) {
+                Chest otherChest = (Chest) otherPartData;
+                BlockFace facing = getFacingDirection(normalFacing, otherChest.getFacing(), otherPart, player);
+
+                chest.setFacingDirection(facing);
+                state.setData(chest);
+
+                otherChest.setFacingDirection(facing);
+                otherPartState.setData(otherChest);
+                otherPartState.update();
+            } else {
+                warnMaterialData(Chest.class, otherPartData);
+            }
         } else {
             warnMaterialData(Chest.class, data);
         }
+    }
+
+    private static BlockFace getFacingDirection(BlockFace myFacing, BlockFace otherFacing, BlockFace connection, GlowPlayer player) {
+        if (connection != myFacing && connection != myFacing.getOppositeFace()) {
+            return myFacing;
+        }
+
+        if (connection != otherFacing && connection != otherFacing.getOppositeFace()) {
+            return otherFacing;
+        }
+
+        float yaw = player.getLocation().getYaw() % 360;
+        yaw = yaw < 0 ? yaw + 360 : yaw;
+
+
+        switch (connection) {
+            case NORTH:
+            case SOUTH:
+                return yaw < 180 ? BlockFace.EAST : BlockFace.WEST;
+            case EAST:
+            case WEST:
+                return yaw > 90 && yaw < 270 ? BlockFace.SOUTH : BlockFace.NORTH;
+            default:
+                GlowServer.logger.warning("Can only handle N/O/S/W BlockFaces, getting face: " + connection);
+                return BlockFace.NORTH;
+        }
+    }
+
+
+    private static final BlockFace[] nearChests = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
+
+    private Collection<BlockFace> searchChests(GlowBlock block) {
+        Collection<BlockFace> chests = new ArrayList<>();
+
+        for (BlockFace face : nearChests) {
+            GlowBlock possibleChest = block.getRelative(face);
+            if (possibleChest.getType() == (isTrapped ? Material.TRAPPED_CHEST : Material.CHEST)) {
+                chests.add(face);
+            }
+        }
+
+        return chests;
+    }
+
+    public BlockFace getAttachedChest(GlowBlock me) {
+        Collection<BlockFace> attachedChests = searchChests(me);
+        if (attachedChests.isEmpty())
+            return null;
+        if (attachedChests.size() > 1) {
+            GlowServer.logger.warning("Chest may only have one near other chest. Found '" + attachedChests + "' near " + me);
+            return null;
+        }
+
+        return attachedChests.iterator().next();
     }
 }

--- a/src/main/java/net/glowstone/block/entity/TEContainer.java
+++ b/src/main/java/net/glowstone/block/entity/TEContainer.java
@@ -26,7 +26,7 @@ public abstract class TEContainer extends TileEntity {
         return inventory;
     }
 
-    public void setContent(ItemStack[] content) {
+    public void setContents(ItemStack[] content) {
         inventory.setContents(content);
     }
 

--- a/src/main/java/net/glowstone/block/entity/TEContainer.java
+++ b/src/main/java/net/glowstone/block/entity/TEContainer.java
@@ -8,6 +8,7 @@ import net.glowstone.util.nbt.TagType;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Base class for container tile entities (those with inventories).
@@ -23,6 +24,10 @@ public abstract class TEContainer extends TileEntity {
 
     public Inventory getInventory() {
         return inventory;
+    }
+
+    public void setContent(ItemStack[] content) {
+        inventory.setContents(content);
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/state/GlowChest.java
+++ b/src/main/java/net/glowstone/block/state/GlowChest.java
@@ -1,10 +1,18 @@
 package net.glowstone.block.state;
 
+import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
+import net.glowstone.block.ItemTable;
+import net.glowstone.block.blocktype.BlockChest;
 import net.glowstone.block.entity.TEChest;
+import net.glowstone.block.entity.TEContainer;
+import net.glowstone.inventory.GlowDoubleChestInventory;
+import net.glowstone.inventory.GlowInventory;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.Chest;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 
 public class GlowChest extends GlowBlockState implements Chest {
 
@@ -22,8 +30,53 @@ public class GlowChest extends GlowBlockState implements Chest {
     }
 
     @Override
+    public boolean update(boolean force, boolean applyPhysics) {
+        ItemStack[] contents = getBlockInventory().getContents();
+
+        boolean result = super.update(force, applyPhysics);
+
+        if (result) {
+            TEChest tileEntity = getTileEntity();
+            tileEntity.setContent(contents);
+            tileEntity.updateInRange();
+        }
+
+        return result;
+    }
+
+    @Override
     public Inventory getInventory() {
-        // todo: handle double chests
-        return getBlockInventory();
+        BlockChest blockType = (BlockChest) ItemTable.instance().getBlock(getType());
+
+        GlowBlock me = this.getBlock();
+
+        BlockFace otherChestPart = blockType.getAttachedChest(me);
+        if (otherChestPart == null) {
+            return getBlockInventory();
+        }
+
+        GlowBlock otherChest = me.getRelative(otherChestPart);
+
+        switch (otherChestPart) {
+            case SOUTH:
+                return getDoubleInventory(me, otherChest, true);
+            case EAST:
+                return getDoubleInventory(me, otherChest, false);
+            case WEST:
+                return getDoubleInventory(otherChest, me, false);
+            case NORTH:
+                return getDoubleInventory(otherChest, me, true);
+
+            default:
+                GlowServer.logger.warning("GlowChest#getInventory() can only handle N/O/S/W BlockFaces, got " + otherChestPart);
+                return getBlockInventory();
+        }
+    }
+
+    private static Inventory getDoubleInventory(GlowBlock firstBlock, GlowBlock secondBlock, boolean isFirstLeft) {
+        Inventory firstSlots = ((TEContainer) firstBlock.getTileEntity()).getInventory();
+        Inventory secondSlots = ((TEContainer) secondBlock.getTileEntity()).getInventory();
+
+        return new GlowDoubleChestInventory((GlowInventory) secondSlots, (GlowInventory) firstSlots, isFirstLeft);
     }
 }

--- a/src/main/java/net/glowstone/block/state/GlowChest.java
+++ b/src/main/java/net/glowstone/block/state/GlowChest.java
@@ -37,7 +37,7 @@ public class GlowChest extends GlowBlockState implements Chest {
 
         if (result) {
             TEChest tileEntity = getTileEntity();
-            tileEntity.setContent(contents);
+            tileEntity.setContents(contents);
             tileEntity.updateInRange();
         }
 

--- a/src/main/java/net/glowstone/inventory/GlowDoubleChestInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowDoubleChestInventory.java
@@ -1,0 +1,154 @@
+package net.glowstone.inventory;
+
+import org.bukkit.Material;
+import org.bukkit.block.DoubleChest;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.DoubleChestInventory;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashMap;
+
+public class GlowDoubleChestInventory extends GlowInventory implements DoubleChestInventory {
+    private static final int SIZE = 54, SPLITTER = 27;
+
+    private final GlowInventory second;
+    private final GlowInventory first;
+    private final boolean firstIsLeft;
+
+    public GlowDoubleChestInventory(GlowInventory first, GlowInventory second, boolean firstIsLeft) {
+        super(null, InventoryType.CHEST, SIZE);
+        this.first = first;
+        this.second = second;
+        this.firstIsLeft = firstIsLeft;
+        fill();
+    }
+
+    public GlowDoubleChestInventory(GlowInventory first, GlowInventory second, boolean firstIsLeft, String title) {
+        super(null, InventoryType.CHEST, SIZE, title);
+        this.first = first;
+        this.second = second;
+        this.firstIsLeft = firstIsLeft;
+        fill();
+    }
+
+    private void fill() {
+        super.replaceContent(0, first.getContents());
+        super.replaceContent(SPLITTER, second.getContents());
+    }
+
+    private void update() {
+        ItemStack[] content = getContents();
+        for (int i = 0; i < content.length; i++) {
+            if (i < SPLITTER) {
+                first.setItem(i, content[i]);
+            } else {
+                second.setItem(i - SPLITTER, content[i]);
+            }
+        }
+    }
+
+    @Override
+    public Inventory getLeftSide() {
+        return firstIsLeft ? first : second;
+    }
+
+    @Override
+    public Inventory getRightSide() {
+        return firstIsLeft ? second : first;
+    }
+
+    @Override
+    public DoubleChest getHolder() {
+        return new DoubleChest(this);
+    }
+
+    /////////////////////////////////////////////////////////////////
+    // Override super methods to track modifying of the inventory
+
+    @Override
+    public void replaceContent(int beginIndex, ItemStack... content) {
+        super.replaceContent(beginIndex, content);
+        update();
+    }
+
+    @Override
+    public void setContents(ItemStack[] content) {
+        super.setContents(content);
+        update();
+    }
+
+    @Override
+    public void addViewer(HumanEntity viewer) {
+        super.addViewer(viewer);
+        first.addViewer(viewer);
+        second.addViewer(viewer);
+    }
+
+    @Override
+    public void removeViewer(HumanEntity viewer) {
+        super.removeViewer(viewer);
+        first.removeViewer(viewer);
+        second.removeViewer(viewer);
+    }
+
+    @Override
+    public void setTitle(String title) {
+        super.setTitle(title);
+        first.setTitle(title);
+        second.setTitle(title);
+    }
+
+    @Override
+    public void setItem(int index, ItemStack item) {
+        super.setItem(index, item);
+        if (index < SPLITTER)
+            first.setItem(index, item);
+        else
+            second.setItem(index - SPLITTER, item);
+    }
+
+    @Override
+    public HashMap<Integer, ItemStack> addItem(ItemStack... items) {
+        HashMap<Integer, ItemStack> result = super.addItem(items);
+        update();
+        return result;
+    }
+
+    @Override
+    public HashMap<Integer, ItemStack> removeItem(ItemStack... items) {
+        HashMap<Integer, ItemStack> result = super.removeItem(items);
+        update();
+        return result;
+    }
+
+    @Override
+    public void remove(int materialId) {
+        super.remove(materialId);
+        update();
+    }
+
+    @Override
+    public void remove(Material material) {
+        super.remove(material);
+        update();
+    }
+
+    @Override
+    public void remove(ItemStack item) {
+        super.remove(item);
+    }
+
+    @Override
+    public void clear(int index) {
+        super.clear(index);
+        update();
+    }
+
+    @Override
+    public void clear() {
+        super.clear();
+        update();
+    }
+}

--- a/src/main/java/net/glowstone/inventory/GlowDoubleChestInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowDoubleChestInventory.java
@@ -34,8 +34,8 @@ public class GlowDoubleChestInventory extends GlowInventory implements DoubleChe
     }
 
     private void fill() {
-        super.replaceContent(0, first.getContents());
-        super.replaceContent(SPLITTER, second.getContents());
+        super.replaceContents(0, first.getContents());
+        super.replaceContents(SPLITTER, second.getContents());
     }
 
     private void update() {
@@ -68,8 +68,8 @@ public class GlowDoubleChestInventory extends GlowInventory implements DoubleChe
     // Override super methods to track modifying of the inventory
 
     @Override
-    public void replaceContent(int beginIndex, ItemStack... content) {
-        super.replaceContent(beginIndex, content);
+    public void replaceContents(int beginIndex, ItemStack... content) {
+        super.replaceContents(beginIndex, content);
         update();
     }
 

--- a/src/main/java/net/glowstone/inventory/GlowInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowInventory.java
@@ -303,7 +303,7 @@ public class GlowInventory implements Inventory {
      * @param beginIndex The index to begin to replace the contents
      * @param items The ItemStack that will replace the existing ones
      */
-    public void replaceContent(int beginIndex, ItemStack... items) {
+    public void replaceContents(int beginIndex, ItemStack... items) {
         for (int i = beginIndex; i < slots.length; i++) {
             if (i >= items.length + beginIndex) {
                 break;

--- a/src/main/java/net/glowstone/inventory/GlowInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowInventory.java
@@ -72,6 +72,7 @@ public class GlowInventory implements Inventory {
 
     /**
      * Add a viewer to the inventory.
+     *
      * @param viewer The HumanEntity to add.
      */
     public void addViewer(HumanEntity viewer) {
@@ -82,6 +83,7 @@ public class GlowInventory implements Inventory {
 
     /**
      * Remove a viewer from the inventory.
+     *
      * @param viewer The HumanEntity to remove.
      */
     public void removeViewer(HumanEntity viewer) {
@@ -92,6 +94,7 @@ public class GlowInventory implements Inventory {
 
     /**
      * Get the type of the specified slot.
+     *
      * @param slot The slot number.
      * @return The SlotType of the slot.
      */
@@ -105,6 +108,7 @@ public class GlowInventory implements Inventory {
      * at the slot, regardless of the slot's current contents. Should return
      * false for crafting output slots or armor slots which cannot accept
      * the given item.
+     *
      * @param slot The slot number.
      * @param stack The stack to add.
      * @return Whether the stack can be added there.
@@ -116,6 +120,7 @@ public class GlowInventory implements Inventory {
     /**
      * Check whether, in a shift-click operation, an item of the specified type
      * may be placed in the given slot.
+     *
      * @param slot The slot number.
      * @param stack The stack to add.
      * @return Whether the stack can be added there.
@@ -126,6 +131,7 @@ public class GlowInventory implements Inventory {
 
     /**
      * Set the custom title of this inventory or reset it to the default.
+     *
      * @param title The new title, or null to reset.
      */
     public void setTitle(String title) {
@@ -289,6 +295,22 @@ public class GlowInventory implements Inventory {
             throw new IllegalArgumentException("Length of items must be " + slots.length);
         }
         System.arraycopy(items, 0, slots, 0, items.length);
+    }
+
+    /**
+     * Replace the current part of this content with the given one, starting by beginIndex.
+     *
+     * @param beginIndex The index to begin to replace the contents
+     * @param items The ItemStack that will replace the existing ones
+     */
+    public void replaceContent(int beginIndex, ItemStack... items) {
+        for (int i = beginIndex; i < slots.length; i++) {
+            if (i >= items.length + beginIndex) {
+                break;
+            }
+
+            slots[i] = items[i - beginIndex];
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This adds all the functionality for double chests:
- correct facing
- correct inventory (loading/saving)

The problem that currently exists is that Bukkit doesn't have MaterialData for TRAPPED_CHESTS. I added TRAPPED_CHEST as BlockChest too, since I assume that TRAPPED_CHESTS should also have a MaterialData of org.bukkit.material.Chest. If this is added to Glowkit it should automatically work with trapped chests correct, but since then placing trapped_chests gives you a warning in the console.
(See: [GlowkitPR](https://github.com/GlowstoneMC/Glowkit/pull/23)

Fixes #263 
Fixes #329 
