### PR TITLE
Add Eclipse project name to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,13 @@ checkstyle {
     configFile = file('etc/checkstyle.xml')
 }
 
+// Eclipse project name
+eclipse {
+    project {
+        name = 'Glowstone'
+    }
+}
+
 // Jar manifest information
 jar.manifest.mainAttributes(
         'Main-Class': mainClassName,


### PR DESCRIPTION
This is another way to fix Eclipse project name as it's required that the project name match directory name so that it can be imported directly as a gradle project into Eclipse.

As it has been discussed in PR #346, we want to preserve artifact names.
