### PR TITLE
Check for creative and sword on break (fixes #349)

### DIFF
--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -49,7 +49,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
                 // emit damage event - cancel by default if holding a sword
                 boolean instaBreak = player.getGameMode() == GameMode.CREATIVE;
                 BlockDamageEvent damageEvent = new BlockDamageEvent(player, block, player.getItemInHand(), instaBreak);
-                if (holding != null && EnchantmentTarget.WEAPON.includes(holding.getType())) {
+                if (player.getGameMode() == GameMode.CREATIVE && holding != null && EnchantmentTarget.WEAPON.includes(holding.getType())) {
                     damageEvent.setCancelled(true);
                 }
                 EventFactory.callEvent(damageEvent);


### PR DESCRIPTION
Add a check for creative when canceling block breaking if the player has a sword in his hand.
