### PR TITLE
Add player visibility API 

### DIFF
--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -1041,7 +1041,7 @@ public final class GlowWorld implements World {
         boolean result = false;
 
         for (GlowPlayer player : getRawPlayers()) {
-            if (player.canSee(key)) {
+            if (player.canSeeChunk(key)) {
                 player.getSession().send(getChunkAt(x, z).toMessage());
                 result = true;
             }

--- a/src/main/java/net/glowstone/block/entity/TileEntity.java
+++ b/src/main/java/net/glowstone/block/entity/TileEntity.java
@@ -41,7 +41,7 @@ public abstract class TileEntity {
     public final void updateInRange() {
         GlowChunk.Key key = new GlowChunk.Key(block.getChunk().getX(), block.getChunk().getZ());
         for (GlowPlayer player : block.getWorld().getRawPlayers()) {
-            if (player.canSee(key)) {
+            if (player.canSeeChunk(key)) {
                 update(player);
             }
         }

--- a/src/main/java/net/glowstone/block/state/GlowNoteBlock.java
+++ b/src/main/java/net/glowstone/block/state/GlowNoteBlock.java
@@ -78,7 +78,7 @@ public class GlowNoteBlock extends GlowBlockState implements NoteBlock {
 
         GlowChunk.Key key = new GlowChunk.Key(getX() >> 4, getZ() >> 4);
         for (GlowPlayer player : getWorld().getRawPlayers()) {
-            if (player.canSee(key)) {
+            if (player.canSeeChunk(key)) {
                 player.playNote(location, instrument, note);
             }
         }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -631,7 +631,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
      * Checks whether the player can see the given chunk.
      * @return If the chunk is known to the player's client.
      */
-    public boolean canSee(GlowChunk.Key chunk) {
+    public boolean canSeeChunk(GlowChunk.Key chunk) {
         return knownChunks.contains(chunk);
     }
 
@@ -639,7 +639,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
      * Checks whether the player can see the given entity.
      * @return If the entity is known to the player's client.
      */
-    public boolean canSee(GlowEntity entity) {
+    public boolean canSeeEntity(GlowEntity entity) {
         return knownEntities.contains(entity);
     }
 
@@ -827,7 +827,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         }
         Message updateMessage = UserListItemMessage.displayNameOne(getUniqueId(), displayName);
         for (GlowPlayer player : server.getOnlinePlayers()) {
-            if (player.canSee((Player) this)) {
+            if (player.canSee(this)) {
                 player.getSession().send(updateMessage);
             }
         }
@@ -1345,7 +1345,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
     public void sendBlockChange(BlockChangeMessage message) {
         // only send message if the chunk is within visible range
         GlowChunk.Key key = new GlowChunk.Key(message.getX() >> 4, message.getZ() >> 4);
-        if (canSee(key)) {
+        if (canSeeChunk(key)) {
             blockChanges.add(message);
         }
     }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -1613,8 +1613,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
     @Override
     public void hidePlayer(Player player) {
         Validate.notNull(player, "player cannot be null");
-        if (equals(player)) return;
-        if (!player.isOnline() || !session.isActive()) return;
+        if (equals(player) || !player.isOnline() || !session.isActive()) return;
         if (hiddenEntities.contains(player.getUniqueId())) return;
 
         hiddenEntities.add(player.getUniqueId());
@@ -1627,12 +1626,11 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
     @Override
     public void showPlayer(Player player) {
         Validate.notNull(player, "player cannot be null");
-        if (equals(player)) return;
-        if (!player.isOnline() || !session.isActive()) return;
+        if (equals(player) || !player.isOnline() || !session.isActive()) return;
         if (!hiddenEntities.contains(player.getUniqueId())) return;
 
         hiddenEntities.remove(player.getUniqueId());
-        session.send(UserListItemMessage.addOne(((GlowPlayer) player).getProfile()));
+        session.send(new UserListItemMessage(UserListItemMessage.Action.ADD_PLAYER, ((GlowPlayer) player).getUserListEntry()));
     }
 
     @Override

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -27,7 +27,6 @@ import net.glowstone.net.protocol.GlowProtocol;
 import net.glowstone.net.protocol.LoginProtocol;
 import net.glowstone.net.protocol.PlayProtocol;
 import net.glowstone.net.protocol.ProtocolType;
-import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 
@@ -284,10 +283,10 @@ public final class GlowSession extends BasicSession {
         Message addMessage = new UserListItemMessage(UserListItemMessage.Action.ADD_PLAYER, player.getUserListEntry());
         List<UserListItemMessage.Entry> entries = new ArrayList<>();
         for (GlowPlayer other : server.getOnlinePlayers()) {
-            if (other != player && other.canSee((Player) player)) {
+            if (other != player && other.canSee(player)) {
                 other.getSession().send(addMessage);
             }
-            if (player.canSee((Player) other)) {
+            if (player.canSee(other)) {
                 entries.add(other.getUserListEntry());
             }
         }
@@ -445,7 +444,7 @@ public final class GlowSession extends BasicSession {
 
         Message userListMessage = UserListItemMessage.removeOne(player.getUniqueId());
         for (GlowPlayer player : server.getOnlinePlayers()) {
-            if (player.canSee((Player) this.player)) {
+            if (player.canSee(this.player)) {
                 player.getSession().send(userListMessage);
             } else {
                 player.stopHidingDisconnectedPlayer(this.player);

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -287,7 +287,9 @@ public final class GlowSession extends BasicSession {
             if (other != player && other.canSee((Player) player)) {
                 other.getSession().send(addMessage);
             }
-            entries.add(other.getUserListEntry());
+            if (player.canSee((Player) other)) {
+                entries.add(other.getUserListEntry());
+            }
         }
         send(new UserListItemMessage(UserListItemMessage.Action.ADD_PLAYER, entries));
     }

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -27,6 +27,7 @@ import net.glowstone.net.protocol.GlowProtocol;
 import net.glowstone.net.protocol.LoginProtocol;
 import net.glowstone.net.protocol.PlayProtocol;
 import net.glowstone.net.protocol.ProtocolType;
+import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 
@@ -283,7 +284,7 @@ public final class GlowSession extends BasicSession {
         Message addMessage = new UserListItemMessage(UserListItemMessage.Action.ADD_PLAYER, player.getUserListEntry());
         List<UserListItemMessage.Entry> entries = new ArrayList<>();
         for (GlowPlayer other : server.getOnlinePlayers()) {
-            if (other != player) {
+            if (other != player && other.canSee((Player) player)) {
                 other.getSession().send(addMessage);
             }
             entries.add(other.getUserListEntry());
@@ -442,7 +443,11 @@ public final class GlowSession extends BasicSession {
 
         Message userListMessage = UserListItemMessage.removeOne(player.getUniqueId());
         for (GlowPlayer player : server.getOnlinePlayers()) {
-            player.getSession().send(userListMessage);
+            if (player.canSee((Player) this.player)) {
+                player.getSession().send(userListMessage);
+            } else {
+                player.stopHidingDisconnectedPlayer(this.player);
+            }
         }
 
         GlowServer.logger.info(player.getName() + " [" + address + "] lost connection");

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
@@ -35,7 +35,7 @@ public final class PlayerSwingArmHandler implements MessageHandler<GlowSession, 
             // play the animation to others
             AnimateEntityMessage toSend = new AnimateEntityMessage(player.getEntityId(), AnimateEntityMessage.OUT_SWING_ARM);
             for (GlowPlayer observer : player.getWorld().getRawPlayers()) {
-                if (observer != player && observer.canSee((GlowEntity) player)) {
+                if (observer != player && observer.canSeeEntity(player)) {
                     observer.getSession().send(toSend);
                 }
             }

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
@@ -2,7 +2,6 @@ package net.glowstone.net.handler.play.player;
 
 import com.flowpowered.networking.MessageHandler;
 import net.glowstone.EventFactory;
-import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.entity.AnimateEntityMessage;


### PR DESCRIPTION
Resolves #121 
This implements the `hidePlayer`, `showPlayer` and `canSee(Player)` methods of `GlowPlayer` as well as performing necessary checks when sending the user list entries (tablist) and spawning the player entities.
Checks when sending chat (as suggested in the ticket) are not performed because (even though undocumented) no other Bukkit implementation does so.
Players will reappear after they reconnect (unless a plugin hides them again) which matches the behavior in CraftBukkit.

No changes were made to the `canSee(GlowChunk.Key)` and `canSee(GlowEntity)` methods as those are (even though similar named) not responsible for determining whether a chunk/entity is hidden from the player but rather whether they have been sent to the client.

This implementation hides players based on their UUIDs and therefore would also allow for hiding all other entities in the  the future.
