### PR TITLE
Convert strings to int and boolean when migrating from the server.properties

### DIFF
--- a/src/main/java/net/glowstone/util/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/ServerConfig.java
@@ -246,7 +246,19 @@ public final class ServerConfig {
 
             for (Key key : Key.values()) {
                 if (key.migrate == Migrate.PROPS && props.containsKey(key.migratePath)) {
-                    config.set(key.path, props.get(key.migratePath));
+                    String value = props.getProperty(key.migratePath);
+                    if (key.def instanceof Integer) {
+                        try {
+                            config.set(key.path, Integer.parseInt(value));
+                        } catch (NumberFormatException e) {
+                            GlowServer.logger.log(Level.WARNING, "Could not migrate " + key.migratePath + " from " + serverProps, e);
+                            continue;
+                        }
+                    } else if (key.def instanceof Boolean) {
+                        config.set(key.path, Boolean.parseBoolean(value));
+                    } else {
+                        config.set(key.path, value);
+                    }
                     migrateStatus = true;
                 }
             }


### PR DESCRIPTION
Ticket: #392 
Convert strings read from the `server.properties` to `int`s or `boolean`s depending on the type of their default value.
If the value in the `server.properties` cannot be converted to an integer but is supposed to be one, prints out a warning and continues with the next property.
