### PR TITLE
Ender portals

### DIFF
--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -87,6 +87,7 @@ public final class ItemTable {
         reg(Material.WEB, new BlockDirectDrops(Material.STRING));
         reg(Material.FIRE, new BlockFire());
         reg(Material.MONSTER_EGGS, new BlockDropless());
+        reg(Material.ENDER_PORTAL_FRAME, new BlockEnderPortalFrame());
         reg(Material.FURNACE, new BlockFurnace());
         reg(Material.LEVER, new BlockLever());
         reg(Material.HOPPER, new BlockHopper());

--- a/src/main/java/net/glowstone/block/blocktype/BlockEnderPortalFrame.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockEnderPortalFrame.java
@@ -1,0 +1,113 @@
+package net.glowstone.block.blocktype;
+
+import net.glowstone.EventFactory;
+import net.glowstone.block.GlowBlock;
+import net.glowstone.block.GlowBlockState;
+import net.glowstone.entity.GlowPlayer;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.PortalType;
+import org.bukkit.World.Environment;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.event.entity.EntityCreatePortalEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BlockEnderPortalFrame extends BlockDropless {
+    private static final BlockFace[] DIRECTION = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
+
+    @Override
+    public void placeBlock(GlowPlayer player, GlowBlockState state, BlockFace face, ItemStack holding, Vector clickedLoc) {
+        state.setType(Material.ENDER_PORTAL_FRAME);
+        switch (getOppositeBlockFace(player.getLocation(), false).getOppositeFace()) {
+        case NORTH:
+            state.setRawData((byte) 0);
+            break;
+        case EAST:
+            state.setRawData((byte) 1);
+            break;
+        case SOUTH:
+            state.setRawData((byte) 2);
+            break;
+        case WEST:
+            state.setRawData((byte) 3);
+            break;
+        default:
+            state.setRawData((byte) 0);
+            break;
+        
+        }
+    }
+
+    @Override
+    public boolean blockInteract(GlowPlayer player, GlowBlock block, BlockFace face, Vector clickedLoc) {
+        ItemStack item = player.getItemInHand();
+        if (item != null && item.getType() == Material.EYE_OF_ENDER) {
+            if ((block.getData() & 0x4) != 0) {
+                return true;
+            }
+            if (player.getGameMode() != GameMode.CREATIVE) {
+                item.setAmount(item.getAmount() - 1);
+            }
+
+            block.setData((byte) (block.getData() | 0x4));
+            if (block.getWorld().getEnvironment() != Environment.THE_END) {
+                searchForCompletedPortal(player, block);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Checks for a completed portal at all relevant positions.
+     */
+    private void searchForCompletedPortal(GlowPlayer player, GlowBlock changed) {
+        for (int i = 0; i < 4; i++) {
+            for (int j = -1; j <= 1; j++) {
+                GlowBlock center = changed.getRelative(DIRECTION[i], 2).getRelative(DIRECTION[(i + 1) % 4], j);
+                if (isCompltetedPortal(center)) {
+                    createPortal(player, center);
+                }
+            }
+        }
+    }
+
+    /**
+     * Check whether there is a completed portal with the specified center.
+     */
+    private boolean isCompltetedPortal(GlowBlock center) {
+        for (int i = 0; i < 4; i++) {
+            for (int j = -1; j <= 1; j++) {
+                GlowBlock block = center.getRelative(DIRECTION[i], 2).getRelative(DIRECTION[(i + 1) % 4], j);
+                if (block.getType() != Material.ENDER_PORTAL_FRAME || (block.getData() & 0x4) == 0) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Spawn the portal and call the {@link EntityCreatePortalEvent}.
+     */
+    private void createPortal(GlowPlayer player, GlowBlock center) {
+        List<BlockState> blocks = new ArrayList<>(9);
+        for (int i = -1; i <= 1; i++) {
+            for (int j = -1; j <= 1; j++) {
+                BlockState state = center.getRelative(i, 0, j).getState();
+                state.setType(Material.ENDER_PORTAL);
+                blocks.add(state);
+            }
+        }
+        if (!EventFactory.callEvent(new EntityCreatePortalEvent(player, blocks, PortalType.ENDER)).isCancelled()) {
+            for (BlockState state : blocks) {
+                state.update(true);
+            }
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -1,6 +1,7 @@
 package net.glowstone.entity;
 
 import com.flowpowered.networking.Message;
+import net.glowstone.EventFactory;
 import net.glowstone.GlowChunk;
 import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
@@ -11,9 +12,16 @@ import net.glowstone.util.Position;
 import org.apache.commons.lang.Validate;
 import org.bukkit.EntityEffect;
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.World.Environment;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityPortalEnterEvent;
+import org.bukkit.event.entity.EntityPortalEvent;
+import org.bukkit.event.entity.EntityPortalExitEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.metadata.MetadataStore;
 import org.bukkit.metadata.MetadataStoreBase;
@@ -303,6 +311,28 @@ public abstract class GlowEntity implements Entity {
         if (ticksLived % (30 * 20) == 0) {
             teleported = true;
         }
+
+        if (hasMoved()) {
+            Block currentBlock = location.getBlock();
+            if (currentBlock.getType() == Material.ENDER_PORTAL) {
+                EventFactory.callEvent(new EntityPortalEnterEvent(this, currentBlock.getLocation()));
+                if (server.getAllowEnd()) {
+                    Location previousLocation = location.clone();
+                    boolean success;
+                    if (getWorld().getEnvironment() == Environment.THE_END) {
+                        success = teleportToSpawn();
+                    } else {
+                        success = teleportToEnd();
+                    }
+                    if (success) {
+                        EntityPortalExitEvent e = EventFactory.callEvent(new EntityPortalExitEvent(this, previousLocation, location.clone(), velocity.clone(), new Vector()));
+                        if (!e.getAfter().equals(velocity)) {
+                            setVelocity(e.getAfter());
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -425,6 +455,54 @@ public abstract class GlowEntity implements Entity {
      */
     public boolean hasRotated() {
         return Position.hasRotated(location, previousLocation);
+    }
+
+    /**
+     * Teleport this entity to the spawn point of the main world.
+     * This is used to teleport out of the End.
+     * @return {@code true} if the teleport was successful.
+     */
+    public boolean teleportToSpawn() {
+        Location target = server.getWorlds().get(0).getSpawnLocation();
+
+        EntityPortalEvent event = EventFactory.callEvent(new EntityPortalEvent(this, location.clone(), target, null));
+        if (event.isCancelled()) {
+            return false;
+        }
+        target = event.getTo();
+
+        teleport(target);
+        return true;
+    }
+
+    /**
+     * Teleport this entity to the End.
+     * If no End world is loaded this does nothing.
+     * @return {@code true} if the teleport was successful.
+     */
+    public boolean teleportToEnd() {
+        if (!server.getAllowEnd()) {
+            return false;
+        }
+        Location target = null;
+        for (World world : server.getWorlds()) {
+            if (world.getEnvironment() == Environment.THE_END) {
+                target = world.getSpawnLocation();
+                break;
+            }
+        }
+        if (target == null) {
+            return false;
+        }
+
+        EntityPortalEvent event = EventFactory.callEvent(new EntityPortalEvent(this, location.clone(), target, null));
+        if (event.isCancelled()) {
+            return false;
+        }
+        target = event.getTo();
+
+        teleport(target);
+        return true;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -462,7 +462,7 @@ public abstract class GlowEntity implements Entity {
      * This is used to teleport out of the End.
      * @return {@code true} if the teleport was successful.
      */
-    public boolean teleportToSpawn() {
+    protected boolean teleportToSpawn() {
         Location target = server.getWorlds().get(0).getSpawnLocation();
 
         EntityPortalEvent event = EventFactory.callEvent(new EntityPortalEvent(this, location.clone(), target, null));
@@ -480,7 +480,7 @@ public abstract class GlowEntity implements Entity {
      * If no End world is loaded this does nothing.
      * @return {@code true} if the teleport was successful.
      */
-    public boolean teleportToEnd() {
+    protected boolean teleportToEnd() {
         if (!server.getAllowEnd()) {
             return false;
         }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -1176,7 +1176,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         spawnAt(target);
         teleported = true;
 
-        awardAchievement(Achievement.THE_END);
+        awardAchievement(Achievement.THE_END, false);
         return true;
     }
 
@@ -1205,7 +1205,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         spawnAt(target);
         teleported = true;
 
-        awardAchievement(Achievement.END_PORTAL);
+        awardAchievement(Achievement.END_PORTAL, false);
         return true;
     }
 
@@ -1429,7 +1429,28 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public void awardAchievement(Achievement achievement) {
+        awardAchievement(achievement, true);
+    }
+
+    /**
+     * Awards the given achievement if the player already has the parent achievement,
+     * otherwise does nothing. If {@code awardParents} is true, award the player all
+     * parent achievements and the given achievement, making this method equivalent
+     * to {@link #awardAchievement(Achievement)}.
+     * @param achievement
+     * @param awardParents
+     */
+    public void awardAchievement(Achievement achievement, boolean awardParents) {
         if (hasAchievement(achievement)) return;
+
+        Achievement parent = achievement.getParent();
+        if (parent != null && !hasAchievement(parent)) {
+            if (awardParents) {
+                awardAchievement(parent, awardParents);
+            } else {
+                return; // player does not have the required parent achievement
+            }
+        }
 
         stats.setAchievement(achievement, true);
         sendAchievement(achievement, true);

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -29,6 +29,7 @@ import net.glowstone.util.TextMessage;
 import net.glowstone.util.TextWrapper;
 import org.apache.commons.lang.Validate;
 import org.bukkit.*;
+import org.bukkit.World.Environment;
 import org.bukkit.configuration.serialization.DelegateDeserialization;
 import org.bukkit.conversations.Conversation;
 import org.bukkit.conversations.ConversationAbandonedEvent;
@@ -1156,6 +1157,55 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         }
 
         teleported = true;
+        return true;
+    }
+
+    @Override
+    public boolean teleportToSpawn() {
+        Location target = getBedSpawnLocation();
+        if (target == null) {
+            target = server.getWorlds().get(0).getSpawnLocation();
+        }
+
+        PlayerPortalEvent event = EventFactory.callEvent(new PlayerPortalEvent(this, location.clone(), target, null));
+        if (event.isCancelled()) {
+            return false;
+        }
+        target = event.getTo();
+
+        spawnAt(target);
+        teleported = true;
+
+        awardAchievement(Achievement.THE_END);
+        return true;
+    }
+
+    @Override
+    public boolean teleportToEnd() {
+        if (!server.getAllowEnd()) {
+            return false;
+        }
+        Location target = null;
+        for (World world : server.getWorlds()) {
+            if (world.getEnvironment() == Environment.THE_END) {
+                target = world.getSpawnLocation();
+                break;
+            }
+        }
+        if (target == null) {
+            return false;
+        }
+
+        PlayerPortalEvent event = EventFactory.callEvent(new PlayerPortalEvent(this, location.clone(), target, null));
+        if (event.isCancelled()) {
+            return false;
+        }
+        target = event.getTo();
+
+        spawnAt(target);
+        teleported = true;
+
+        awardAchievement(Achievement.END_PORTAL);
         return true;
     }
 

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -1439,16 +1439,17 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
      * to {@link #awardAchievement(Achievement)}.
      * @param achievement
      * @param awardParents
+     * @return {@code true} if the achievement was awarded, {@code false} otherwise
      */
-    public void awardAchievement(Achievement achievement, boolean awardParents) {
-        if (hasAchievement(achievement)) return;
+    public boolean awardAchievement(Achievement achievement, boolean awardParents) {
+        if (hasAchievement(achievement)) return false;
 
         Achievement parent = achievement.getParent();
         if (parent != null && !hasAchievement(parent)) {
             if (awardParents) {
                 awardAchievement(parent, awardParents);
             } else {
-                return; // player does not have the required parent achievement
+                return false; // player does not have the required parent achievement
             }
         }
 
@@ -1456,6 +1457,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         sendAchievement(achievement, true);
 
         // todo: make an announcement if that's enabled
+        return true;
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -1161,7 +1161,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
     }
 
     @Override
-    public boolean teleportToSpawn() {
+    protected boolean teleportToSpawn() {
         Location target = getBedSpawnLocation();
         if (target == null) {
             target = server.getWorlds().get(0).getSpawnLocation();
@@ -1181,7 +1181,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
     }
 
     @Override
-    public boolean teleportToEnd() {
+    protected boolean teleportToEnd() {
         if (!server.getAllowEnd()) {
             return false;
         }


### PR DESCRIPTION
Ticket #325 

This adds the ability to place eye of ender into the ender portal frames. Once placed the surrounding blocks are scanned for a complete ender portal and if one is found the ender portal blocks are placed.
This also adds directional placement of ender portal frames and teleports the player/entities into the End / the Overworld on contact with an ender portal block.

Note that for a full portal to be formed, the last ender portal frame must point inwards in vanilla minecraft due to the way it detects the rest of the portal. The orientation of all other blocks is not checked. This is not the case with this PR, every orientation of the last portal frame will be sufficient to generate the portal.

The following events are now thrown for End portals:
- EntityPortalEvent
- EntityPortalEnterEvent
- EntityPortalExitEvent
- PlayerPortalEvent
- EntityCreatePortalEvent
