### PR TITLE
Prevent time out when main thread is blocked

### DIFF
--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -378,6 +378,12 @@ public final class GlowSession extends BasicSession {
             GlowServer.logger.info("[" + address + "] kicked: " + reason);
         }
 
+        if (timedOut) {
+            quitReason = "timed out";
+            // consider this session gone
+            onDisconnect();
+        }
+
         if (quitReason == null) {
             quitReason = "kicked";
         }
@@ -413,8 +419,8 @@ public final class GlowSession extends BasicSession {
         }
 
         // connection timed out, we should disconnect them
-        if (timedOut) {
-            disconnect("Timed out");
+        if (timedOut && player != null) {
+            disconnect("Timed out", true);
         }
     }
 

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -107,7 +107,7 @@ public final class GlowSession extends BasicSession {
     private int writeTimeoutCounter = 0;
 
     /**
-     * Whether to kick the player the next time its updated. This is set to {@code true}
+     * Whether to kick the player the next time it's updated. This is set to {@code true}
      * when a timeout occurs in order for the player to be kicked from the main thread.
      */
     private boolean timedOut = false;

--- a/src/main/java/net/glowstone/net/SessionRegistry.java
+++ b/src/main/java/net/glowstone/net/SessionRegistry.java
@@ -25,6 +25,15 @@ public final class SessionRegistry {
     }
 
     /**
+     * Pulses all the sessions in an asynchronous thread.
+     */
+    public void pulseAsync() {
+        for (GlowSession session : sessions.keySet()) {
+            session.pulseAsync();
+        }
+    }
+
+    /**
      * Adds a new session.
      * @param session The session to add.
      */

--- a/src/main/java/net/glowstone/net/message/play/game/PingMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/game/PingMessage.java
@@ -1,11 +1,16 @@
 package net.glowstone.net.message.play.game;
 
-import com.flowpowered.networking.Message;
+import com.flowpowered.networking.AsyncableMessage;
 import lombok.Data;
 
 @Data
-public final class PingMessage implements Message {
+public final class PingMessage implements AsyncableMessage {
 
     private final int pingId;
+
+    @Override
+    public boolean isAsync() {
+        return true;
+    }
 
 }


### PR DESCRIPTION
Ticket: #411 
This prevents the player from getting kicked during or after an expensive operation in the main thread by moving the necessary checks into another thread which will never be blocked by any expensive operations.
This thread would also be the place where one would put a potential future watchdog system for the main thread.
Testing can be done with any expensive main-thread-locking plugin such as WorldEdit or ScriptCraft (`/js java.lang.Thread.sleep(30000)`) by blocking the main thread for more than 30 seconds.

---

_Edited by turt2live_

**Related Links:**
- Ticket: #411 
