### PR TITLE
Add a script that fetches glowkit PRs for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,22 @@
 language: java
 jdk: oraclejdk7
 
-# Compile and package JAR and set build properties
-install: ./gradlew clean build remap
+
+
+install:
+
+  # Required for fetch_glowkit_pr.sh
+  - "sudo apt-get install jq"
+
+  # Try to fetch required glowkit PRs, if any.
+  - "./etc/fetch_glowkit_pr.sh $TRAVIS_PULL_REQUEST || echo 'Glowkit build failed - trying to continue anyway'"
+
+  # Fetch gradle stuff, so it doesn't appear in the script step
+  - "./gradlew clean"
+
+script:
+  # Compile and package JAR and set build properties
+  - "./gradlew build remap"
 
 after_success:
   # Check if commit is not a pull request, if repo is official, and branch is master, generate and deploy artifacts and reports

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@
 language: java
 jdk: oraclejdk7
 
-
-
 install:
 
   # Required for fetch_glowkit_pr.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk: oraclejdk7
 install:
 
   # Required for fetch_glowkit_pr.sh
-  - "sudo apt-get install jq"
+  - "[[ $TRAVIS_PULL_REQUEST == false ]] || sudo apt-get install jq"
 
   # Try to fetch required glowkit PRs, if any.
   - "./etc/fetch_glowkit_pr.sh $TRAVIS_PULL_REQUEST || echo 'Glowkit build failed - trying to continue anyway'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,15 @@ install:
   - "./etc/fetch_glowkit_pr.sh $TRAVIS_PULL_REQUEST || echo 'Glowkit build failed - trying to continue anyway'"
 
   # Fetch gradle stuff, so it doesn't appear in the script step
-  - "./gradlew clean"
+  - "gradle clean"
 
 script:
   # Compile and package JAR and set build properties
-  - "./gradlew build remap"
+  - "gradle build remap"
 
 after_success:
   # Check if commit is not a pull request, if repo is official, and branch is master, generate and deploy artifacts and reports
-  - "[[ $TRAVIS_PULL_REQUEST == false ]] && [[ $TRAVIS_REPO_SLUG == GlowstoneMC/Glowstone ]] && [[ $TRAVIS_BRANCH == master ]] && ./gradlew publish"
+  - "[[ $TRAVIS_PULL_REQUEST == false ]] && [[ $TRAVIS_REPO_SLUG == GlowstoneMC/Glowstone ]] && [[ $TRAVIS_BRANCH == master ]] && gradle publish"
 
 # Notification services
 notifications:

--- a/etc/fetch_glowkit_pr.sh
+++ b/etc/fetch_glowkit_pr.sh
@@ -35,11 +35,19 @@ elif [ $(echo "$GLOWKIT_PR" | wc -l) != 1 ]; then
     exit 0
 fi
 
+# Create a temp directory to work in
+TEMP=$(mktemp -d --tmpdir glowkit-XXXXXXXXXX)
+
 # Fetch the PR from the other repo just like travis-ci does
-git clone --depth=50 git://github.com/GlowstoneMC/Glowkit.git glowkit-temp
-cd glowkit-temp
+git clone --depth=50 git://github.com/GlowstoneMC/Glowkit.git $TEMP
+pushd $TEMP
 git fetch origin +refs/pull/$GLOWKIT_PR/merge:
 git checkout -qf FETCH_HEAD
 
 # Actually build it!
 mvn clean install -Dmaven.javadoc.skip=true
+
+# Remove all the evidence
+popd
+echo "Removing $TEMP"
+rm -rf $TEMP

--- a/etc/fetch_glowkit_pr.sh
+++ b/etc/fetch_glowkit_pr.sh
@@ -21,7 +21,7 @@ echo "-------------------------------------------------------------------------"
 echo
 
 # Extract from body
-GLOWKIT_PR=$(echo $PR_BODY | egrep -o 'Glowkit/pull/[0-9]+' | sed 's#Glowkit/pull/##')
+GLOWKIT_PR=$(echo $PR_BODY | egrep -o 'GlowstoneMC/Glowkit(/pull/|#)[0-9]+' | sed -r 's#GlowstoneMC/Glowkit(\#|/pull/)##')
 
 echo "PR links found:" $GLOWKIT_PR
 echo

--- a/etc/fetch_glowkit_pr.sh
+++ b/etc/fetch_glowkit_pr.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+[ "$1" == "false" ] && echo "Skipping glowkit build - not a PR" && exit 0
+
+# exit at the first failure
+set -e
+
+PR_ID=$1
+
+
+# public repo access token, to bypass rate limiting. will probably revoke later
+ACCESS_TOKEN=053b27d9bf05b86706b531e8cd63afcf1af3bada:x-oauth-basic
+
+# Fetch the body of this PR
+PR_BODY=$(curl -u $ACCESS_TOKEN -s https://api.github.com/repos/GlowstoneMC/Glowstone/pulls/$PR_ID | jq -r '.body' | sed 's/\r$//')
+
+echo "Glowstone PR: $PR_ID. Body:"
+echo "-------------------------------------------------------------------------"
+echo "$PR_BODY"
+echo "-------------------------------------------------------------------------"
+echo
+
+# Extract from body
+GLOWKIT_PR=$(echo $PR_BODY | egrep -o 'Glowkit/pull/[0-9]+' | sed 's#Glowkit/pull/##')
+
+echo "PR links found:" $GLOWKIT_PR
+echo
+
+# Validate
+if [ -z "$GLOWKIT_PR" ]; then
+    echo "No PR links found. Aborting."
+    exit 0
+elif [ $(echo "$GLOWKIT_PR" | wc -l) != 1 ]; then
+    echo "More than one PR link found. Aborting"
+    exit 0
+fi
+
+# Fetch the PR from the other repo just like travis-ci does
+git clone --depth=50 git://github.com/GlowstoneMC/Glowkit.git glowkit-temp
+cd glowkit-temp
+git fetch origin +refs/pull/$GLOWKIT_PR/merge:
+git checkout -qf FETCH_HEAD
+
+# Actually build it!
+mvn clean install -Dmaven.javadoc.skip=true

--- a/etc/fetch_glowkit_pr.sh
+++ b/etc/fetch_glowkit_pr.sh
@@ -14,25 +14,25 @@ curl_wrapped() {
 }
 
 # Fetch the body of this PR
-PR_BODY=$(curl_wrapped https://api.github.com/repos/GlowstoneMC/Glowstone/pulls/$PR_ID | jq -r '.body' | sed 's/\r$//')
+pr_body=$(curl_wrapped https://api.github.com/repos/GlowstoneMC/Glowstone/pulls/$PR_ID | jq -r '.body' | sed 's/\r$//')
 
 echo "Glowstone PR: $PR_ID. Body:"
 echo "-------------------------------------------------------------------------"
-echo "$PR_BODY"
+echo "$pr_body"
 echo "-------------------------------------------------------------------------"
 echo
 
 # Extract from body
-GLOWKIT_PR=$(echo $PR_BODY | egrep -o 'GlowstoneMC/Glowkit(/pull/|#)[0-9]+' | sed -r 's#GlowstoneMC/Glowkit(\#|/pull/)##')
+glowkit_pr=$(echo $pr_body | egrep -o 'GlowstoneMC/Glowkit(/pull/|#)[0-9]+' | sed -r 's#GlowstoneMC/Glowkit(\#|/pull/)##')
 
-echo "PR links found:" $GLOWKIT_PR
+echo "PR links found:" $glowkit_pr
 echo
 
 # Validate
-if [ -z "$GLOWKIT_PR" ]; then
+if [ -z "$glowkit_pr" ]; then
     echo "No PR links found. Aborting."
     exit 0
-elif [ $(echo "$GLOWKIT_PR" | wc -l) != 1 ]; then
+elif [ $(echo "$glowkit_pr" | wc -l) != 1 ]; then
     echo "More than one PR link found. Aborting"
     exit 0
 fi
@@ -43,7 +43,7 @@ TEMP=$(mktemp -d --tmpdir glowkit-XXXXXXXXXX)
 # Fetch the PR from the other repo just like travis-ci does
 git clone --depth=50 git://github.com/GlowstoneMC/Glowkit.git $TEMP
 pushd $TEMP
-git fetch origin +refs/pull/$GLOWKIT_PR/merge:
+git fetch origin +refs/pull/$glowkit_pr/merge:
 git checkout -qf FETCH_HEAD
 
 # Actually build it!

--- a/etc/fetch_glowkit_pr.sh
+++ b/etc/fetch_glowkit_pr.sh
@@ -7,10 +7,17 @@ set -e
 
 PR_ID=$1
 
+# access token for testing purposes, will be revoked soon
+# please set GITHUB_ACCESS_TOKEN in the environment and remove this
+GITHUB_ACCESS_TOKEN=053b27d9bf05b86706b531e8cd63afcf1af3bada:x-oauth-basic
+
 curl_wrapped() {
-    # public repo access token, to bypass rate limiting. will probably revoke later
-    GITHUB_ACCESS_TOKEN=053b27d9bf05b86706b531e8cd63afcf1af3bada:x-oauth-basic
-    curl -u $GITHUB_ACCESS_TOKEN -s $@
+    if [ -n "$GITHUB_ACCESS_TOKEN" ]; then
+        curl -u $GITHUB_ACCESS_TOKEN -s $@
+    else
+        echo >&2 'Warning: no access token provided - strict rate limits will apply!'
+        curl -s $@
+    fi
 }
 
 # Fetch the body of this PR

--- a/etc/fetch_glowkit_pr.sh
+++ b/etc/fetch_glowkit_pr.sh
@@ -7,12 +7,14 @@ set -e
 
 PR_ID=$1
 
-
-# public repo access token, to bypass rate limiting. will probably revoke later
-ACCESS_TOKEN=053b27d9bf05b86706b531e8cd63afcf1af3bada:x-oauth-basic
+curl_wrapped() {
+    # public repo access token, to bypass rate limiting. will probably revoke later
+    GITHUB_ACCESS_TOKEN=053b27d9bf05b86706b531e8cd63afcf1af3bada:x-oauth-basic
+    curl -u $GITHUB_ACCESS_TOKEN -s $@
+}
 
 # Fetch the body of this PR
-PR_BODY=$(curl -u $ACCESS_TOKEN -s https://api.github.com/repos/GlowstoneMC/Glowstone/pulls/$PR_ID | jq -r '.body' | sed 's/\r$//')
+PR_BODY=$(curl_wrapped https://api.github.com/repos/GlowstoneMC/Glowstone/pulls/$PR_ID | jq -r '.body' | sed 's/\r$//')
 
 echo "Glowstone PR: $PR_ID. Body:"
 echo "-------------------------------------------------------------------------"


### PR DESCRIPTION
Also reorganize .travis.yml slightly (actual build stuff goes in the script step, preparations go in the install step)

The script uses the github API to fetch the pull request body (which is needed to find the relevant PR links).

Since the github api has very strict rate limits for unauthenticated users, I've included an [oauth personal access token](https://github.com/settings/tokens/new) with scope for public repositories only. This means that compared to unauthenticated access, it's only useful to bypass the rate limit

I'd still recommend using the travis encryption features for the token, just in case. I'd like to revoke mine as soon as testing is done.

Also note that using the encryption features means the script won't work in other repos, but this isn't an issue since it's also hardcoded to fetch PRs from Glowstone/Glowstone and Glowstone/Glowkit.

Did some testing for it [here](https://travis-ci.org/dequis/Glowstone/pull_requests) and [here](https://travis-ci.org/dequis/Glowstone/builds). The commit labeled "TESTING SHIT" (now reverted) calls the script three times with hardcoded ids instead of `$TRAVIS_PULL_REQUEST`. These PRs are:
- #374 - no glowkit PRs required
- #402 - two PRs ~~required~~ mentioned, ignored by the script. The author of that PR said they aren't needed.
- #413 - one PR required, detected correctly by the script and built successfully, but in the end the build fails because the glowstone side doesn't have the required changes. For the purposes of my script, this means it works.
