### PR TITLE
Added method blockDestroy to BlockType class

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -117,7 +117,7 @@ public class BlockType extends ItemType {
     }
 
     /**
-     * Called when a player attempts to destroys a block.
+     * Called when a player attempts to destroy a block.
      * @param player The player interacting
      * @param block The block the player destroyed
      * @param face The block face

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -117,6 +117,16 @@ public class BlockType extends ItemType {
     }
 
     /**
+     * Called when a player attempts to destroys a block.
+     * @param player The player interacting
+     * @param block The block the player destroyed
+     * @param face The block face
+     * @param clickedLoc Where the destroy occurred
+     */
+    public void blockDestroy(GlowPlayer player, GlowBlock block, BlockFace face, Vector blockLoc) {
+    }
+
+    /**
      * Called when a player attempts to place a block on an existing block of
      * this type. Used to determine if the placement should occur into the air
      * adjacent to the block (normal behavior), or absorbed into the block

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -123,7 +123,8 @@ public class BlockType extends ItemType {
      * @param face The block face
      * @param clickedLoc Where the destroy occurred
      */
-    public void blockDestroy(GlowPlayer player, GlowBlock block, BlockFace face, Vector blockLoc) {
+    public void blockDestroy(GlowPlayer player, GlowBlock block, BlockFace face, Vector clickedLoc) {
+        // do nothing
     }
 
     /**

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -1,12 +1,14 @@
 package net.glowstone.net.handler.play.player;
 
-import com.flowpowered.networking.MessageHandler;
 import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
+import net.glowstone.block.ItemTable;
+import net.glowstone.block.blocktype.BlockType;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.DiggingMessage;
+
 import org.bukkit.Effect;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -18,6 +20,9 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+
+import com.flowpowered.networking.MessageHandler;
 
 public final class DiggingHandler implements MessageHandler<GlowSession, DiggingMessage> {
     @Override
@@ -81,6 +86,10 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
                 BlockPlacementHandler.revert(player, block);
                 return;
             }
+
+            BlockType blockType = ItemTable.instance().getBlock(block.getType());
+            if (blockType != null)
+                blockType.blockDestroy(player, block, face, new Vector(message.getX(), message.getY(), message.getZ()));
 
             // destroy the block
             if (!block.isEmpty() && !block.isLiquid() && player.getGameMode() != GameMode.CREATIVE) {


### PR DESCRIPTION
I added this method because it's needed for the proper removal of Doors and Beds. There might also be a need for a separate method for when a block is destroyed by other events like TNT.

---

_Edited by turt2live_

**Related Links:**
- Ticket: #441 
