### PR TITLE
Call PlayerMoveEvent

### DIFF
--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
@@ -1,23 +1,34 @@
 package net.glowstone.net.handler.play.player;
 
 import com.flowpowered.networking.MessageHandler;
+import net.glowstone.EventFactory;
 import net.glowstone.net.GlowSession;
+import net.glowstone.net.message.play.game.PositionRotationMessage;
 import net.glowstone.net.message.play.player.PlayerUpdateMessage;
 import org.bukkit.Location;
+import org.bukkit.event.player.PlayerMoveEvent;
 
 public final class PlayerUpdateHandler implements MessageHandler<GlowSession, PlayerUpdateMessage> {
 
     @Override
     public void handle(GlowSession session, PlayerUpdateMessage message) {
-        Location original = session.getPlayer().getLocation();
-        Location newLoc = original.clone();
+        Location originLoc = session.getPlayer().getLocation();
+        Location newLoc = originLoc.clone();
         message.update(newLoc);
 
         // don't let players move more than 16 blocks in a single packet.
         // this is NOT robust hack prevention - only to prevent client
         // confusion about where its actual location is (e.g. during login)
-        if (newLoc.distanceSquared(original) > 16 * 16) {
+        if (newLoc.distanceSquared(originLoc) > 16 * 16) {
             return;
+        }
+
+        if (!originLoc.equals(newLoc)) {
+            final PlayerMoveEvent event = EventFactory.callEvent(new PlayerMoveEvent(session.getPlayer(), originLoc, newLoc));
+            if (event.isCancelled()) {
+                session.send(new PositionRotationMessage(originLoc, session.getPlayer().getEyeHeight(true)));
+                return;
+            }
         }
 
         // do stuff with onGround if we need to

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
@@ -12,23 +12,23 @@ public final class PlayerUpdateHandler implements MessageHandler<GlowSession, Pl
 
     @Override
     public void handle(GlowSession session, PlayerUpdateMessage message) {
-        Location originLoc = session.getPlayer().getLocation();
-        Location newLoc = originLoc.clone();
+        Location original = session.getPlayer().getLocation();
+        Location newLoc = original.clone();
         Location finalLoc = newLoc;
         message.update(newLoc);
 
         // don't let players move more than 16 blocks in a single packet.
         // this is NOT robust hack prevention - only to prevent client
         // confusion about where its actual location is (e.g. during login)
-        if (newLoc.distanceSquared(originLoc) > 16 * 16) {
+        if (newLoc.distanceSquared(original) > 16 * 16) {
             return;
         }
 
-        if (!originLoc.equals(newLoc)) {
-            final PlayerMoveEvent event = EventFactory.callEvent(new PlayerMoveEvent(session.getPlayer(), originLoc, newLoc));
+        if (!original.equals(newLoc)) {
+            final PlayerMoveEvent event = EventFactory.callEvent(new PlayerMoveEvent(session.getPlayer(), original, newLoc));
 
             if (event.isCancelled()) {
-                finalLoc = originLoc;
+                finalLoc = original;
             } else if (!event.getTo().equals(newLoc)) {
                 finalLoc = event.getTo();
             }

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
@@ -25,9 +25,7 @@ public final class PlayerUpdateHandler implements MessageHandler<GlowSession, Pl
         }
 
         if (!originLoc.equals(newLoc)) {
-            session.getPlayer().sendMessage("before " + newLoc.toString());
             final PlayerMoveEvent event = EventFactory.callEvent(new PlayerMoveEvent(session.getPlayer(), originLoc, newLoc));
-            session.getPlayer().sendMessage("after  " + newLoc.toString());
 
             if (event.isCancelled()) {
                 finalLoc = originLoc;


### PR DESCRIPTION
Based on JeromSar's code, with several improvements

Particularly, the event isn't called if both locations are equal. This decreases event spam but not as much as craftbukkit does - that would require keeping state in the player of the last sent move event, which would be awkward.

[MiniPython](https://github.com/SpaceManiac/MiniPython) test plugin here: https://gist.github.com/dequis/0c05ebfa93cf9984f877
