### PR TITLE
Add the ability to be damaged by players (melee)

### DIFF
--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -488,6 +488,16 @@ public final class GlowWorld implements World {
         return result;
     }
 
+    /**
+     * Gets an entity by it's internal ID.
+     *
+     * @param id the entity's ID
+     * @return the entity found, or null otherwise
+     */
+    public GlowEntity getEntityById(int id) {
+        return entities.getEntity(id);
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Various malleable world properties
 

--- a/src/main/java/net/glowstone/constants/AttackDamage.java
+++ b/src/main/java/net/glowstone/constants/AttackDamage.java
@@ -11,13 +11,26 @@ public final class AttackDamage {
     }
 
     /**
-     * Gets the damage an item in-hand would cause without added benefits.
+     * Gets the damage an item in-hand would cause without added benefits. This
+     * assumes a non-critical attack.
      *
      * @param material the item type
      *
      * @return the raw damage caused by that item
      */
     public static float getMeleeDamage(Material material) {
+        return getMeleeDamage(material, false);
+    }
+
+    /**
+     * Gets the damage an item in-hand would cause without added benefits.
+     *
+     * @param material the item type
+     * @param critical true if critical damage should be returned
+     *
+     * @return the raw damage caused by that item
+     */
+    public static float getMeleeDamage(Material material, boolean critical) {
         if (material == null) return 0.0f;
 
         switch (material) {
@@ -54,21 +67,7 @@ public final class AttackDamage {
     }
 
     /**
-     * Gets the damage an in-hand item would cause without added benefits upon
-     * a critical hit.
-     *
-     * @param material the item type
-     *
-     * @return the raw damage caused by that item during a critical hit
-     */
-    public static float getCriticalMeleeDamage(Material material) {
-        float raw = getMeleeDamage(material);
-        return raw * 1.5f;
-    }
-
-    /**
-     * Gets the durability loss of the supplied type for a successful hit. This
-     * assumes that the supplied type was used for a melee attack.
+     * Gets the durability loss of the supplied type for a successful hit.
      *
      * @param material the item type
      *
@@ -100,7 +99,5 @@ public final class AttackDamage {
                 return 0;
         }
     }
-
-    // TODO: Other methods for stuff like lava contact, fire, arrows, etc
 
 }

--- a/src/main/java/net/glowstone/constants/AttackDamage.java
+++ b/src/main/java/net/glowstone/constants/AttackDamage.java
@@ -14,6 +14,7 @@ public final class AttackDamage {
      * Gets the damage an item in-hand would cause without added benefits.
      *
      * @param material the item type
+     *
      * @return the raw damage caused by that item
      */
     public static float getMeleeDamage(Material material) {
@@ -57,6 +58,7 @@ public final class AttackDamage {
      * a critical hit.
      *
      * @param material the item type
+     *
      * @return the raw damage caused by that item during a critical hit
      */
     public static float getCriticalMeleeDamage(Material material) {
@@ -69,37 +71,34 @@ public final class AttackDamage {
      * assumes that the supplied type was used for a melee attack.
      *
      * @param material the item type
+     *
      * @return the durability points lost, or 0
      */
     public static short getMeleeDurabilityLoss(Material material) {
-        short loss = 0;
-        if (material != null) {
-            switch (material) {
-                case WOOD_AXE:
-                case GOLD_AXE:
-                case STONE_AXE:
-                case DIAMOND_AXE:
-                case WOOD_PICKAXE:
-                case GOLD_PICKAXE:
-                case IRON_PICKAXE:
-                case DIAMOND_PICKAXE:
-                case WOOD_SPADE:
-                case GOLD_SPADE:
-                case IRON_SPADE:
-                case DIAMOND_SPADE:
-                    loss = 2;
-                    break;
-                case WOOD_SWORD:
-                case GOLD_SWORD:
-                case IRON_SWORD:
-                case DIAMOND_SWORD:
-                    loss = 1;
-                    break;
-                default:
-                    break;
-            }
+        if (material == null) return 0;
+
+        switch (material) {
+            case WOOD_AXE:
+            case GOLD_AXE:
+            case STONE_AXE:
+            case DIAMOND_AXE:
+            case WOOD_PICKAXE:
+            case GOLD_PICKAXE:
+            case IRON_PICKAXE:
+            case DIAMOND_PICKAXE:
+            case WOOD_SPADE:
+            case GOLD_SPADE:
+            case IRON_SPADE:
+            case DIAMOND_SPADE:
+                return 2;
+            case WOOD_SWORD:
+            case GOLD_SWORD:
+            case IRON_SWORD:
+            case DIAMOND_SWORD:
+                return 1;
+            default:
+                return 0;
         }
-        return loss;
     }
 
     // TODO: Other methods for stuff like lava contact, fire, arrows, etc

--- a/src/main/java/net/glowstone/constants/AttackDamage.java
+++ b/src/main/java/net/glowstone/constants/AttackDamage.java
@@ -19,18 +19,6 @@ public final class AttackDamage {
      * @return the raw damage caused by that item
      */
     public static float getMeleeDamage(Material material) {
-        return getMeleeDamage(material, false);
-    }
-
-    /**
-     * Gets the damage an item in-hand would cause without added benefits.
-     *
-     * @param material the item type
-     * @param critical true if critical damage should be returned
-     *
-     * @return the raw damage caused by that item
-     */
-    public static float getMeleeDamage(Material material, boolean critical) {
         if (material == null) return 0.0f;
 
         switch (material) {
@@ -64,6 +52,19 @@ public final class AttackDamage {
             default:
                 return 1.0f;
         }
+    }
+
+    /**
+     * Gets the damage an item in-hand would cause without added benefits.
+     *
+     * @param material the item type
+     * @param critical true if critical damage should be returned
+     *
+     * @return the raw damage caused by that item
+     */
+    public static float getMeleeDamage(Material material, boolean critical) {
+        float raw = getMeleeDamage(material);
+        return critical ? raw * 1.5f : raw;
     }
 
     /**

--- a/src/main/java/net/glowstone/constants/AttackDamage.java
+++ b/src/main/java/net/glowstone/constants/AttackDamage.java
@@ -3,11 +3,11 @@ package net.glowstone.constants;
 import org.bukkit.Material;
 
 /**
- * Maps item types to damage values
+ * Maps attack damage values
  */
-public final class ItemDamage {
+public final class AttackDamage {
 
-    private ItemDamage() {
+    private AttackDamage() {
     }
 
     /**
@@ -16,7 +16,7 @@ public final class ItemDamage {
      * @param material the item type
      * @return the raw damage caused by that item
      */
-    public static float getDamageFor(Material material) {
+    public static float getMeleeDamage(Material material) {
         if (material == null) return 0.0f;
 
         switch (material) {
@@ -59,8 +59,8 @@ public final class ItemDamage {
      * @param material the item type
      * @return the raw damage caused by that item during a critical hit
      */
-    public static float getCriticalDamageFor(Material material) {
-        float raw = getDamageFor(material);
+    public static float getCriticalMeleeDamage(Material material) {
+        float raw = getMeleeDamage(material);
         return raw * 1.5f;
     }
 
@@ -71,7 +71,7 @@ public final class ItemDamage {
      * @param material the item type
      * @return the durability points lost, or 0
      */
-    public static short getDurabilityLoss(Material material) {
+    public static short getMeleeDurabilityLoss(Material material) {
         short loss = 0;
         if (material != null) {
             switch (material) {

--- a/src/main/java/net/glowstone/constants/ItemDamage.java
+++ b/src/main/java/net/glowstone/constants/ItemDamage.java
@@ -1,0 +1,95 @@
+package net.glowstone.constants;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Maps item types to damage values
+ */
+public final class ItemDamage {
+
+    private ItemDamage() {
+    }
+
+    /**
+     * Gets the damage an item in-hand would cause without added benefits.
+     *
+     * @param material the item type
+     * @return the raw damage caused by that item
+     */
+    public static float getDamageFor(Material material) {
+        if (material == null) return 0.0f;
+
+        switch (material) {
+            case WOOD_SPADE:
+            case GOLD_SPADE:
+                return 2.0f;
+            case STONE_SPADE:
+            case WOOD_PICKAXE:
+            case GOLD_PICKAXE:
+                return 3.0f;
+            case IRON_SPADE:
+            case STONE_PICKAXE:
+            case WOOD_AXE:
+            case GOLD_AXE:
+                return 4.0f;
+            case DIAMOND_SPADE:
+            case IRON_PICKAXE:
+            case STONE_AXE:
+            case WOOD_SWORD:
+            case GOLD_SWORD:
+                return 5.0f;
+            case DIAMOND_PICKAXE:
+            case IRON_AXE:
+            case STONE_SWORD:
+                return 6.0f;
+            case DIAMOND_AXE:
+            case IRON_SWORD:
+                return 7.0f;
+            case DIAMOND_SWORD:
+                return 8.0f;
+            default:
+                return 1.0f;
+        }
+    }
+
+    /**
+     * Gets the damage an in-hand item would cause without added benefits upon
+     * a critical hit.
+     *
+     * @param material the item type
+     * @return the raw damage caused by that item during a critical hit
+     */
+    public static float getCriticalDamageFor(Material material) {
+        float raw = getDamageFor(material);
+        return raw * 1.5f;
+    }
+
+    /**
+     * Applies durability loss, if applicable, to the item for a successful hit.
+     *
+     * @param item the item to damage
+     */
+    public static void applyDurabilityLoss(ItemStack item) {
+        if (item != null) {
+            switch (item.getType()) {
+                case WOOD_AXE:
+                case GOLD_AXE:
+                case STONE_AXE:
+                case DIAMOND_AXE:
+                case WOOD_PICKAXE:
+                case GOLD_PICKAXE:
+                case IRON_PICKAXE:
+                case DIAMOND_PICKAXE:
+                case WOOD_SPADE:
+                case GOLD_SPADE:
+                case IRON_SPADE:
+                case DIAMOND_SPADE:
+                    item.setDurability((short) (item.getDurability() - 2));
+            }
+        }
+    }
+
+    // TODO: Other methods for stuff like lava contact, fire, arrows, etc
+
+}

--- a/src/main/java/net/glowstone/constants/ItemDamage.java
+++ b/src/main/java/net/glowstone/constants/ItemDamage.java
@@ -1,7 +1,6 @@
 package net.glowstone.constants;
 
 import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
 
 /**
  * Maps item types to damage values
@@ -66,13 +65,16 @@ public final class ItemDamage {
     }
 
     /**
-     * Applies durability loss, if applicable, to the item for a successful hit.
+     * Gets the durability loss of the supplied type for a successful hit. This
+     * assumes that the supplied type was used for a melee attack.
      *
-     * @param item the item to damage
+     * @param material the item type
+     * @return the durability points lost, or 0
      */
-    public static void applyDurabilityLoss(ItemStack item) {
-        if (item != null) {
-            switch (item.getType()) {
+    public static short getDurabilityLoss(Material material) {
+        short loss = 0;
+        if (material != null) {
+            switch (material) {
                 case WOOD_AXE:
                 case GOLD_AXE:
                 case STONE_AXE:
@@ -85,18 +87,19 @@ public final class ItemDamage {
                 case GOLD_SPADE:
                 case IRON_SPADE:
                 case DIAMOND_SPADE:
-                    item.setDurability((short) (item.getDurability() + 2));
+                    loss = 2;
                     break;
                 case WOOD_SWORD:
                 case GOLD_SWORD:
                 case IRON_SWORD:
                 case DIAMOND_SWORD:
-                    item.setDurability((short) (item.getDurability() + 1));
+                    loss = 1;
                     break;
                 default:
                     break;
             }
         }
+        return loss;
     }
 
     // TODO: Other methods for stuff like lava contact, fire, arrows, etc

--- a/src/main/java/net/glowstone/constants/ItemDamage.java
+++ b/src/main/java/net/glowstone/constants/ItemDamage.java
@@ -87,6 +87,12 @@ public final class ItemDamage {
                 case DIAMOND_SPADE:
                     item.setDurability((short) (item.getDurability() + 2));
                     break;
+                case WOOD_SWORD:
+                case GOLD_SWORD:
+                case IRON_SWORD:
+                case DIAMOND_SWORD:
+                    item.setDurability((short) (item.getDurability() + 1));
+                    break;
                 default:
                     break;
             }

--- a/src/main/java/net/glowstone/constants/ItemDamage.java
+++ b/src/main/java/net/glowstone/constants/ItemDamage.java
@@ -86,6 +86,9 @@ public final class ItemDamage {
                 case IRON_SPADE:
                 case DIAMOND_SPADE:
                     item.setDurability((short) (item.getDurability() + 2));
+                    break;
+                default:
+                    break;
             }
         }
     }

--- a/src/main/java/net/glowstone/constants/ItemDamage.java
+++ b/src/main/java/net/glowstone/constants/ItemDamage.java
@@ -85,7 +85,7 @@ public final class ItemDamage {
                 case GOLD_SPADE:
                 case IRON_SPADE:
                 case DIAMOND_SPADE:
-                    item.setDurability((short) (item.getDurability() - 2));
+                    item.setDurability((short) (item.getDurability() + 2));
             }
         }
     }

--- a/src/main/java/net/glowstone/net/codec/play/player/InteractEntityCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/player/InteractEntityCodec.java
@@ -12,7 +12,7 @@ public final class InteractEntityCodec implements Codec<InteractEntityMessage> {
     public InteractEntityMessage decode(ByteBuf buf) throws IOException {
         int id = ByteBufUtils.readVarInt(buf);
         int action = ByteBufUtils.readVarInt(buf);
-        if (action == InteractEntityMessage.Action.ATTACK_AT.ordinal()) {
+        if (action == InteractEntityMessage.Action.INTERACT_AT.ordinal()) {
             float targetX = buf.readFloat();
             float targetY = buf.readFloat();
             float targetZ = buf.readFloat();
@@ -25,7 +25,7 @@ public final class InteractEntityCodec implements Codec<InteractEntityMessage> {
     public ByteBuf encode(ByteBuf buf, InteractEntityMessage message) throws IOException {
         ByteBufUtils.writeVarInt(buf, message.getId());
         ByteBufUtils.writeVarInt(buf, message.getAction());
-        if (message.getAction() == InteractEntityMessage.Action.ATTACK_AT.ordinal()) {
+        if (message.getAction() == InteractEntityMessage.Action.INTERACT_AT.ordinal()) {
             buf.writeFloat(message.getTargetX());
             buf.writeFloat(message.getTargetY());
             buf.writeFloat(message.getTargetZ());

--- a/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
@@ -1,12 +1,61 @@
 package net.glowstone.net.handler.play.player;
 
 import com.flowpowered.networking.MessageHandler;
+import com.google.common.collect.ImmutableList;
+import net.glowstone.GlowServer;
+import net.glowstone.constants.ItemDamage;
+import net.glowstone.entity.GlowEntity;
+import net.glowstone.entity.GlowLivingEntity;
+import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.InteractEntityMessage;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
 
 public final class InteractEntityHandler implements MessageHandler<GlowSession, InteractEntityMessage> {
+
+    private final List<GameMode> invulnerableGamemodes = ImmutableList.of(GameMode.CREATIVE, GameMode.SPECTATOR);
+
     @Override
     public void handle(GlowSession session, InteractEntityMessage message) {
-        // todo
+        GlowPlayer player = session.getPlayer();
+
+        // You can't do anything when you're dead
+        if (player.isDead()) {
+            GlowServer.logger.info("Player " + player + " tried to interact with an entity while dead");
+            return;
+        }
+
+        GlowEntity possibleTarget = player.getWorld().getEntityById(message.getId());
+        GlowLivingEntity target = possibleTarget instanceof GlowLivingEntity ? (GlowLivingEntity) possibleTarget : null;
+
+        if (message.getAction() == InteractEntityMessage.Action.ATTACK.ordinal()) {
+            if (target == null) {
+                GlowServer.logger.info("Player " + player + " tried to attack an entity that does not exist");
+            } else {
+                ItemStack hand = player.getItemInHand();
+                Material type = hand == null ? Material.AIR : hand.getType();
+
+                boolean critical = false; // TODO: Actual critical hit check
+                float damage = critical ? ItemDamage.getCriticalDamageFor(type) : ItemDamage.getDamageFor(type);
+
+                if (!target.isDead() && (!(target instanceof Player) || !invulnerableGamemodes.contains(((Player) target).getGameMode()))) {
+                    target.damage(damage, player, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
+                    ItemDamage.applyDurabilityLoss(hand);
+                    player.updateInventory();
+                }
+            }
+        } else if (message.getAction() == InteractEntityMessage.Action.ATTACK_AT.ordinal()) {
+            // TODO: Interaction with entity (right click)
+        } else if (message.getAction() == InteractEntityMessage.Action.INTERACT.ordinal()) {
+            // TODO: Handle something (unknown cause for this action)
+        } else {
+            GlowServer.logger.info("Player " + player + " sent unknown interact action: " + message.getAction());
+        }
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
@@ -44,7 +44,7 @@ public final class InteractEntityHandler implements MessageHandler<GlowSession, 
                 Material type = hand == null ? Material.AIR : hand.getType();
 
                 boolean critical = false; // TODO: Actual critical hit check
-                float damage = critical ? AttackDamage.getCriticalMeleeDamage(type) : AttackDamage.getMeleeDamage(type);
+                float damage = AttackDamage.getMeleeDamage(type, critical);
 
                 // TODO: Calculate damage modifiers
                 // ... also make sure the correct event constructor is used

--- a/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
@@ -2,6 +2,7 @@ package net.glowstone.net.handler.play.player;
 
 import com.flowpowered.networking.MessageHandler;
 import com.google.common.collect.ImmutableList;
+import net.glowstone.EventFactory;
 import net.glowstone.GlowServer;
 import net.glowstone.constants.ItemDamage;
 import net.glowstone.entity.GlowEntity;
@@ -12,6 +13,7 @@ import net.glowstone.net.message.play.player.InteractEntityMessage;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.inventory.ItemStack;
 
@@ -45,9 +47,15 @@ public final class InteractEntityHandler implements MessageHandler<GlowSession, 
                 float damage = critical ? ItemDamage.getCriticalDamageFor(type) : ItemDamage.getDamageFor(type);
 
                 if (!target.isDead() && (!(target instanceof Player) || !invulnerableGamemodes.contains(((Player) target).getGameMode()))) {
-                    target.damage(damage, player, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
-                    ItemDamage.applyDurabilityLoss(hand);
-                    player.updateInventory();
+                    // TODO: Calculate damage modifiers
+                    // ... also make sure the correct event constructor is used
+                    EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(player, target, EntityDamageEvent.DamageCause.ENTITY_ATTACK, damage);
+                    EventFactory.callEvent(event);
+                    if (!event.isCancelled()) {
+                        target.damage(damage, player, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
+                        ItemDamage.applyDurabilityLoss(hand);
+                        player.updateInventory();
+                    }
                 }
             }
         } else if (message.getAction() == InteractEntityMessage.Action.ATTACK_AT.ordinal()) {

--- a/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
@@ -4,7 +4,7 @@ import com.flowpowered.networking.MessageHandler;
 import com.google.common.collect.ImmutableList;
 import net.glowstone.EventFactory;
 import net.glowstone.GlowServer;
-import net.glowstone.constants.ItemDamage;
+import net.glowstone.constants.AttackDamage;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.GlowLivingEntity;
 import net.glowstone.entity.GlowPlayer;
@@ -44,7 +44,7 @@ public final class InteractEntityHandler implements MessageHandler<GlowSession, 
                 Material type = hand == null ? Material.AIR : hand.getType();
 
                 boolean critical = false; // TODO: Actual critical hit check
-                float damage = critical ? ItemDamage.getCriticalDamageFor(type) : ItemDamage.getDamageFor(type);
+                float damage = critical ? AttackDamage.getCriticalMeleeDamage(type) : AttackDamage.getMeleeDamage(type);
 
                 // TODO: Calculate damage modifiers
                 // ... also make sure the correct event constructor is used
@@ -57,7 +57,7 @@ public final class InteractEntityHandler implements MessageHandler<GlowSession, 
                         target.damage(damage, player, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
 
                         // Apply durability loss (if applicable)
-                        short durabilityLoss = ItemDamage.getDurabilityLoss(type);
+                        short durabilityLoss = AttackDamage.getMeleeDurabilityLoss(type);
                         if (durabilityLoss > 0) {
                             // Yes, this actually subtracts
                             hand.setDurability((short) (hand.getDurability() + durabilityLoss));

--- a/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
@@ -66,10 +66,10 @@ public final class InteractEntityHandler implements MessageHandler<GlowSession, 
                     }
                 }
             }
-        } else if (message.getAction() == InteractEntityMessage.Action.ATTACK_AT.ordinal()) {
-            // TODO: Interaction with entity (right click)
+        } else if (message.getAction() == InteractEntityMessage.Action.INTERACT_AT.ordinal()) {
+            // TODO: Interaction with entity at a specified location (X, Y, and Z are present in the message)
         } else if (message.getAction() == InteractEntityMessage.Action.INTERACT.ordinal()) {
-            // TODO: Handle something (unknown cause for this action)
+            // TODO: Interaction with something (X, Y, and Z are NOT present in the message)
         } else {
             GlowServer.logger.info("Player " + player + " sent unknown interact action: " + message.getAction());
         }

--- a/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
@@ -58,7 +58,7 @@ public final class InteractEntityHandler implements MessageHandler<GlowSession, 
 
                         // Apply durability loss (if applicable)
                         short durabilityLoss = AttackDamage.getMeleeDurabilityLoss(type);
-                        if (durabilityLoss > 0) {
+                        if (durabilityLoss > 0 && hand != null) {
                             // Yes, this actually subtracts
                             hand.setDurability((short) (hand.getDurability() + durabilityLoss));
                         }

--- a/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
@@ -46,14 +46,22 @@ public final class InteractEntityHandler implements MessageHandler<GlowSession, 
                 boolean critical = false; // TODO: Actual critical hit check
                 float damage = critical ? ItemDamage.getCriticalDamageFor(type) : ItemDamage.getDamageFor(type);
 
+                // TODO: Calculate damage modifiers
+                // ... also make sure the correct event constructor is used
+
                 if (!target.isDead() && (!(target instanceof Player) || !invulnerableGamemodes.contains(((Player) target).getGameMode()))) {
-                    // TODO: Calculate damage modifiers
-                    // ... also make sure the correct event constructor is used
                     EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(player, target, EntityDamageEvent.DamageCause.ENTITY_ATTACK, damage);
                     EventFactory.callEvent(event);
+
                     if (!event.isCancelled()) {
                         target.damage(damage, player, EntityDamageEvent.DamageCause.ENTITY_ATTACK);
-                        ItemDamage.applyDurabilityLoss(hand);
+
+                        // Apply durability loss (if applicable)
+                        short durabilityLoss = ItemDamage.getDurabilityLoss(type);
+                        if (durabilityLoss > 0) {
+                            // Yes, this actually subtracts
+                            hand.setDurability((short) (hand.getDurability() + durabilityLoss));
+                        }
                         player.updateInventory();
                     }
                 }

--- a/src/main/java/net/glowstone/net/message/play/player/InteractEntityMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/player/InteractEntityMessage.java
@@ -18,7 +18,7 @@ public final class InteractEntityMessage implements Message {
     public enum Action {
         INTERACT,
         ATTACK,
-        ATTACK_AT
+        INTERACT_AT
     }
 }
 


### PR DESCRIPTION
This PR adds the ability for players to be melee attacked by other players. This does not handle things like potions, arrows, etc. Specified non-standard weapons are damaged upon impact as well.

Included is a mapping of item type to damage "force". The same utility class can also critical hits for whoever the poor soul that does that is. 

Some additional utility methods were added for future support beyond damage, but they are directly used by this PR. 

---

_Edited by turt2live_

**Related Links:**
- Ticket: #203 
