### PR TITLE
Fix Hoe interaction with coarse dirt and podzol

### DIFF
--- a/src/main/java/net/glowstone/block/itemtype/ItemHoe.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemHoe.java
@@ -12,10 +12,14 @@ public class ItemHoe extends ItemType {
 
     @Override
     public void rightClickBlock(GlowPlayer player, GlowBlock target, BlockFace face, ItemStack holding, Vector clickedLoc) {
-        if ((target.getType() == Material.GRASS || target.getType() == Material.DIRT) &&
+        if ((target.getType() == Material.GRASS || (target.getType() == Material.DIRT && target.getData() == 0)) &&
                 target.getRelative(BlockFace.UP).getType() == Material.AIR) {
             target.getWorld().playSound(target.getLocation().add(0.5D, 0.5D, 0.5D), Sound.STEP_GRAVEL, 1, 0.8F);
             target.setType(Material.SOIL);
+        } else if (target.getType() == Material.DIRT && target.getData() == 1 && // coarse dirt
+                target.getRelative(BlockFace.UP).getType() == Material.AIR) {
+            target.getWorld().playSound(target.getLocation().add(0.5D, 0.5D, 0.5D), Sound.STEP_GRAVEL, 1, 0.8F);
+            target.setData((byte) 0); // changing it to normal dirt
         }
     }
 }


### PR DESCRIPTION
I introduced a bug related to farming with Hoe interaction: the block data isn't checked and so it's possible to turn podzol and coarse dirt into soil.
The expected behavior in vanilla 1.8 is that podzol is not interactable with Hoe, and coarse dirt turns into normal dirt.

This commit fixes the problem.
