### PR TITLE
Fix race conditions

### DIFF
--- a/src/main/java/net/glowstone/net/GlowNetworkServer.java
+++ b/src/main/java/net/glowstone/net/GlowNetworkServer.java
@@ -39,7 +39,7 @@ public final class GlowNetworkServer implements ConnectionManager {
 
     @Override
     public Session newSession(Channel c) {
-        GlowSession session = new GlowSession(server, c);
+        GlowSession session = new GlowSession(server, c, this);
         server.getSessionRegistry().add(session);
         return session;
     }

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -1,9 +1,11 @@
 package net.glowstone.net;
 
 import com.flowpowered.networking.AsyncableMessage;
+import com.flowpowered.networking.ConnectionManager;
 import com.flowpowered.networking.Message;
 import com.flowpowered.networking.MessageHandler;
 import com.flowpowered.networking.session.BasicSession;
+
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -27,10 +29,12 @@ import net.glowstone.net.protocol.GlowProtocol;
 import net.glowstone.net.protocol.LoginProtocol;
 import net.glowstone.net.protocol.PlayProtocol;
 import net.glowstone.net.protocol.ProtocolType;
+
 import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 
 import javax.crypto.SecretKey;
+
 import java.net.InetSocketAddress;
 import java.util.*;
 import java.util.logging.Level;
@@ -52,6 +56,11 @@ public final class GlowSession extends BasicSession {
      * The server this session belongs to.
      */
     private final GlowServer server;
+
+    /**
+     * The connection manager this session belongs to.
+     */
+    private final ConnectionManager connectionManager;
 
     /**
      * The Random for this session
@@ -136,9 +145,10 @@ public final class GlowSession extends BasicSession {
      * @param server The server this session belongs to.
      * @param channel The channel associated with this session.
      */
-    public GlowSession(GlowServer server, Channel channel) {
+    public GlowSession(GlowServer server, Channel channel, ConnectionManager connectionManager) {
         super(channel, ProtocolType.HANDSHAKE.getProtocol());
         this.server = server;
+        this.connectionManager = connectionManager;
         address = super.getAddress();
     }
 
@@ -433,6 +443,8 @@ public final class GlowSession extends BasicSession {
 
         // check if the client is disconnected
         if (disconnected) {
+            connectionManager.sessionInactivated(this);
+
             if (player == null) {
                 return;
             }

--- a/src/main/java/net/glowstone/net/message/login/EncryptionKeyResponseMessage.java
+++ b/src/main/java/net/glowstone/net/message/login/EncryptionKeyResponseMessage.java
@@ -1,12 +1,18 @@
 package net.glowstone.net.message.login;
 
-import com.flowpowered.networking.Message;
+import com.flowpowered.networking.AsyncableMessage;
+
 import lombok.Data;
 
 @Data
-public final class EncryptionKeyResponseMessage implements Message {
+public final class EncryptionKeyResponseMessage implements AsyncableMessage {
 
     private final byte[] sharedSecret;
     private final byte[] verifyToken;
+
+    @Override
+    public boolean isAsync() {
+        return true;
+    }
 
 }

--- a/src/main/java/net/glowstone/net/pipeline/MessageHandler.java
+++ b/src/main/java/net/glowstone/net/pipeline/MessageHandler.java
@@ -41,7 +41,6 @@ public final class MessageHandler extends SimpleChannelInboundHandler<Message> {
     public void channelInactive(ChannelHandlerContext ctx) {
         Session session = this.session.get();
         session.onDisconnect();
-        connectionManager.sessionInactivated(session);
     }
 
     @Override


### PR DESCRIPTION
There are actually a lot of race conditions in Glowstone's network implementation. This PR fixes two notable ones that were reported.
#421

This is caused by the player entity being removed from an asynchronous thread while the synchronous thread is iterating over the map of entities.
This is resolved by removing the player entity from the synchronous thread.
#154

This is actually a very rare race condition, but it is nice to see that it was reproduced. This is where the channel is disconnected asynchronously at the exact same time that the GlowSession.pulse(); synchronous method is called. Because the EncryptionKeyResponse is handled on the synchronous thread, we would then handle it, and since we are not in the PlayProtocol state yet, we wouldn't acknowledge that the session has disconnected.

Due to the way that we fix #421 adding a "disconnected" variable instead of relying on it being in the PlayProtocol to be able to notice if it's disconnected, this is naively fixed or the window is actually narrowed for this issue to be a lot more slim, however it is not a proper fix, and there is still definitely a silent race condition.

The real solution to this issue is to handle the EncryptionKeyResponse asynchronously.
