### PR TITLE
Fixed window click logic

### DIFF
--- a/src/main/java/net/glowstone/inventory/GlowAnvilInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowAnvilInventory.java
@@ -1,8 +1,11 @@
 package net.glowstone.inventory;
 
+import net.glowstone.entity.GlowPlayer;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.ItemStack;
 
 public class GlowAnvilInventory extends GlowInventory implements AnvilInventory {
 
@@ -21,5 +24,11 @@ public class GlowAnvilInventory extends GlowInventory implements AnvilInventory 
     @Override
     public int getRawSlots() {
         return 0;
+    }
+
+    @Override
+    public void handleShiftClick(GlowPlayer player, InventoryView view, int clickedSlot, ItemStack clickedItem) {
+        clickedItem = player.getInventory().tryToFillSlots(clickedItem, 9, 36, 0, 9);
+        view.setItem(clickedSlot, clickedItem);
     }
 }

--- a/src/main/java/net/glowstone/inventory/GlowFurnaceInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowFurnaceInventory.java
@@ -1,8 +1,10 @@
 package net.glowstone.inventory;
 
+import net.glowstone.entity.GlowPlayer;
 import org.bukkit.block.Furnace;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.FurnaceInventory;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 
 public class GlowFurnaceInventory extends GlowInventory implements FurnaceInventory {
@@ -52,5 +54,11 @@ public class GlowFurnaceInventory extends GlowInventory implements FurnaceInvent
     @Override
     public Furnace getHolder() {
         return (Furnace) super.getHolder();
+    }
+
+    @Override
+    public void handleShiftClick(GlowPlayer player, InventoryView view, int clickedSlot, ItemStack clickedItem) {
+        clickedItem = player.getInventory().tryToFillSlots(clickedItem, 9, 36, 0, 9);
+        view.setItem(clickedSlot, clickedItem);
     }
 }

--- a/src/main/java/net/glowstone/inventory/GlowInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowInventory.java
@@ -1,12 +1,14 @@
 package net.glowstone.inventory;
 
 import net.glowstone.constants.ItemIds;
+import net.glowstone.entity.GlowPlayer;
 import org.bukkit.Material;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.inventory.InventoryType.SlotType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.*;
@@ -123,6 +125,79 @@ public class GlowInventory implements Inventory {
      */
     public boolean itemShiftClickAllowed(int slot, ItemStack stack) {
         return itemPlaceAllowed(slot, stack);
+    }
+
+    /**
+     * Handle a shift click in this inventory by the specified player.
+     * The default implementation distributes items from the right to the left
+     * and from the bottom to the top.
+     * @param player The player who clicked
+     * @param view The inventory view in which was clicked
+     * @param clickedSlot The slot in the view
+     * @param clickedItem The item at which was clicked
+     */
+    public void handleShiftClick(GlowPlayer player, InventoryView view, int clickedSlot, ItemStack clickedItem) {
+        clickedItem = player.getInventory().tryToFillSlots(clickedItem, 8, -1, 35, 8);
+        view.setItem(clickedSlot, clickedItem);
+    }
+
+    /**
+     * Tries to put the given items into the specified slots of this inventory
+     * from the start slot (inclusive) to the end slot (exclusive).
+     * The slots are supplied in pairs, first the start then the end slots.
+     * This will first try to fill up all partial slots and if items are still
+     * left after doing so, it places them into the first empty slot.
+     * If no empty slot was found and there are still items left, their returned
+     * from this method.
+     * @param stack The items to place down
+     * @param slots Pairs of start/end slots
+     * @return The remaining items or {@code null} if non are remaining
+     */
+    public ItemStack tryToFillSlots(ItemStack stack, int...slots) {
+        if (slots.length % 2 != 0) {
+            throw new IllegalArgumentException("Slots must be pairs.");
+        }
+        // First empty slot, -1 if no empty slot was found yet
+        int firstEmpty = -1;
+        for (int s = 0; s < slots.length && stack.getAmount() > 0; s += 2) {
+            // Iterate through all pairs of start and end slots
+            int start = slots[s];
+            int end = slots[s + 1];
+            int delta = start < end ? 1 : -1;
+            for (int i = start; i != end && stack.getAmount() > 0; i += delta) {
+                // Check whether shift clicking is allowed in that slot of the inventory
+                if (!itemShiftClickAllowed(i, stack)) {
+                    continue;
+                }
+
+                ItemStack currentStack = getItem(i);
+                if (currentStack == null) {
+                    if (firstEmpty == -1) {
+                        firstEmpty = i; // Found first empty slot
+                    }
+                } else if (currentStack.isSimilar(stack)) { // Non empty slot of similar items, try to fill stack
+                    // Calculate the amount of transferable items
+                    int amount = currentStack.getAmount();
+                    int maxStackSize = Math.min(currentStack.getMaxStackSize(), getMaxStackSize());
+                    int transfer = Math.min(stack.getAmount(), maxStackSize - amount);
+                    if (transfer > 0) {
+                        // And if there are any, transfer them
+                        currentStack.setAmount(amount + transfer);
+                        stack.setAmount(stack.getAmount() - transfer);
+                    }
+                    setItem(i, currentStack);
+                }
+            }
+        }
+        if (stack.getAmount() <= 0) {
+            stack = null;
+        }
+        // If there are still items left, place them in the first empty slot (if any)
+        if (stack != null && firstEmpty != -1) {
+            setItem(firstEmpty, stack);
+            stack = null;
+        }
+        return stack;
     }
 
     /**

--- a/src/main/java/net/glowstone/inventory/WindowClickLogic.java
+++ b/src/main/java/net/glowstone/inventory/WindowClickLogic.java
@@ -3,6 +3,7 @@ package net.glowstone.inventory;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.inventory.InventoryType.SlotType;
 import org.bukkit.inventory.ItemStack;
 
 /**
@@ -111,6 +112,10 @@ public final class WindowClickLogic {
                     return InventoryAction.DROP_ALL_CURSOR;
                 }
 
+                if (slot == SlotType.ARMOR) {
+                    return InventoryAction.PLACE_ONE;
+                }
+
                 if (slotItem == null) {
                     return InventoryAction.PLACE_ALL;
                 }
@@ -216,6 +221,22 @@ public final class WindowClickLogic {
             case PLACE_ONE:
             case PLACE_ALL:
             case PLACE_SOME:
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Check if a given InventoryAction involves taking items from the slot.
+     * @param action The InventoryAction.
+     * @return True if the slot is to be added to the cursor.
+     */
+    public static boolean isPickupAction(InventoryAction action) {
+        switch (action) {
+            case PICKUP_ALL:
+            case PICKUP_HALF:
+            case PICKUP_ONE:
+            case PICKUP_SOME:
                 return true;
         }
         return false;

--- a/src/main/java/net/glowstone/net/handler/play/inv/CreativeItemHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/CreativeItemHandler.java
@@ -1,16 +1,35 @@
 package net.glowstone.net.handler.play.inv;
 
 import com.flowpowered.networking.MessageHandler;
+import net.glowstone.EventFactory;
+import net.glowstone.constants.ItemIds;
 import net.glowstone.entity.GlowPlayer;
+import net.glowstone.inventory.GlowInventory;
 import net.glowstone.inventory.GlowInventoryView;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.inv.CreativeItemMessage;
+import net.glowstone.net.message.play.inv.SetWindowSlotMessage;
 import org.bukkit.GameMode;
+import org.bukkit.event.inventory.InventoryCreativeEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.inventory.InventoryType.SlotType;
+import org.bukkit.inventory.InventoryView;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Objects;
 
 public final class CreativeItemHandler implements MessageHandler<GlowSession, CreativeItemMessage> {
     @Override
     public void handle(GlowSession session, CreativeItemMessage message) {
         final GlowPlayer player = session.getPlayer();
+        final GlowInventory inv = player.getInventory();
+        // CraftBukkit does use a inventory view with both inventories set to the player's inventory
+        // for the creative inventory as there is no second inventory (no crafting) visible for the client
+        final InventoryView view = new GlowInventoryView(player, InventoryType.CREATIVE, inv, inv);
+        final int viewSlot = message.getSlot();
+        final int slot = view.convertSlot(viewSlot);
+        ItemStack stack = ItemIds.sanitize(message.getItem());
+        final SlotType type = inv.getSlotType(slot);
 
         // only if creative mode
         if (player.getGameMode() != GameMode.CREATIVE) {
@@ -26,13 +45,31 @@ public final class CreativeItemHandler implements MessageHandler<GlowSession, Cr
 
         // clicking outside drops the item
         if (message.getSlot() < 0) {
-            player.drop(message.getItem());
+            InventoryCreativeEvent event = EventFactory.callEvent(new InventoryCreativeEvent(view, SlotType.OUTSIDE, -999, stack));
+            if (event.isCancelled()) {
+                session.send(new SetWindowSlotMessage(-1, -1, stack));
+            } else {
+                player.drop(event.getCursor());
+            }
             return;
         }
 
-        // todo: filter item for validity
+        // if the content hasn't changed, ignore the message
+        // this happens quiet often as the client tends to update the whole inventory at once
+        if (Objects.equals(stack, view.getItem(viewSlot))) {
+            return;
+        }
+
+        InventoryCreativeEvent event = EventFactory.callEvent(new InventoryCreativeEvent(view, type, viewSlot, stack));
+        if (event.isCancelled()) {
+            // send original slot to player to prevent async inventories
+            player.sendItemChange(viewSlot, view.getItem(viewSlot));
+            // don't keep track of player's current item, just give them back what they tried to place
+            session.send(new SetWindowSlotMessage(-1, -1, stack));
+            return;
+        }
 
         // in the creative inventory everything is handled client side
-        player.getOpenInventory().setItem(message.getSlot(), message.getItem());
+        view.setItem(viewSlot, event.getCursor());
     }
 }


### PR DESCRIPTION
This tries to fix all window click logic.
Related ticket: #1 
### New features:
- Adds shift clicking logic
- Handle taking items from crafting result and call `GlowCraftingInventory.craft()` accordingly
### Fixes:
- Fixed hotbar swapping (number keys)
- Prevent items from being placed in the wrong slots (dirt as their pants, placing items in the output of crafting table, etc.)
- Fixed double-clicks not taking all items from hotbar (when the player is in their inventory, double-click wasn't collecting the hotbar slots 6-9)
- Fixed dragging items creating stacks with too many items (splitting a stack of items on top of another one crafted stacks with more than 64 items)
### Not included in this PR:
- Removing items from the crafting matrix (this should be done in `CraftingManager.removeItems`). Note that this causes your whole inventory to be filled when you shift-click at the output slot of a crafting recipe. This bug will vanish once said method is implemented.
- Filtering of items for all different kinds of inventories (`itemShiftClickAllowed` and `itemPlaceAllowed` methods). This PR only implements those for the player inventory (armor slots).

Plugin used to test the InventoryClickEvent: [WindowClickTest.py](https://gist.github.com/Johni0702/d55f9b42938e8d3a8a43) ([MiniPython](https://github.com/SpaceManiac/MiniPython))

---

_Edited by turt2live_

**Related Links:**
- Ticket: #1 
