### PR TITLE
Fix placement issues with red sandstone stairs / slabs

### DIFF
--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -48,6 +48,7 @@ public final class ItemTable {
         reg(Material.BOOKSHELF, new BlockDirectDrops(Material.BOOK, 3));
         reg(Material.CLAY, new BlockDirectDrops(Material.CLAY_BALL, 4));
         reg(Material.DOUBLE_STEP, new BlockDoubleSlab());
+        reg(Material.DOUBLE_STEP_2, new BlockDoubleSlab());
         reg(Material.SOIL, new BlockDirectDrops(Material.DIRT));
         reg(Material.GLASS, new BlockDropless());
         reg(Material.THIN_GLASS, new BlockDropless());
@@ -109,8 +110,10 @@ public final class ItemTable {
         reg(Material.SPRUCE_WOOD_STAIRS, new BlockStairs());
         reg(Material.SMOOTH_STAIRS, new BlockStairs());
         reg(Material.WOOD_STAIRS, new BlockStairs());
+        reg(Material.RED_SANDSTONE_STAIRS, new BlockStairs());
         reg(Material.STEP, new BlockSlab());
         reg(Material.WOOD_STEP, new BlockSlab());
+        reg(Material.STEP_2, new BlockSlab());
         reg(Material.HAY_BLOCK, new BlockHay());
         reg(Material.QUARTZ_BLOCK, new BlockQuartz());
         reg(Material.LOG, new BlockLog());

--- a/src/main/java/net/glowstone/block/blocktype/BlockSlab.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSlab.java
@@ -23,6 +23,10 @@ public class BlockSlab extends BlockType {
             state.setType(Material.WOOD_DOUBLE_STEP);
             state.setRawData((byte) holding.getDurability());
             return;
+        } else if (state.getBlock().getType() == Material.STEP_2) {
+            state.setType(Material.DOUBLE_STEP_2);
+            state.setRawData((byte) holding.getDurability());
+            return;
         }
 
         super.placeBlock(player, state, face, holding, clickedLoc);
@@ -41,7 +45,7 @@ public class BlockSlab extends BlockType {
     private boolean matchingType(GlowBlock block, BlockFace face, ItemStack holding, boolean ignoreFace) {
         byte blockData = block.getData();
         byte holdingData = (byte) holding.getDurability();
-        return (block.getType() == Material.STEP || block.getType() == Material.WOOD_STEP) &&
+        return (block.getType() == Material.STEP || block.getType() == Material.WOOD_STEP || block.getType() == Material.STEP_2) &&
                 block.getType() == holding.getType() &&
                 ((face == BlockFace.UP && blockData == holdingData) ||
                         (face == BlockFace.DOWN && blockData - 8 == holdingData) ||


### PR DESCRIPTION
For some reason mojang decided to use new item IDs for these - they just needed to be added to ItemTable, and include them in a few conditions in BlockSlab.

To test:
- Stairs: just place them in any direction or inverted. Old behavior sticks them with a single orientation.
- Slabs: place two red sandstone slabs on top of each other, they should stack into a double slab. Old behavior leaves two single slabs, the second one floating above with a space in the middle.

---

_Edited by turt2live_

**Related Links:**
- Ticket: #285 
