### PR TITLE
Add config setters and setWhitelist

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1297,7 +1297,7 @@ public final class GlowServer implements Server {
     @Override
     public void setWhitelist(boolean enabled) {
         whitelistEnabled = enabled;
-        config.setBoolean(ServerConfig.Key.WHITELIST, whitelistEnabled);
+        config.set(ServerConfig.Key.WHITELIST, whitelistEnabled);
         config.save();
     }
 

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1298,6 +1298,7 @@ public final class GlowServer implements Server {
     public void setWhitelist(boolean enabled) {
         whitelistEnabled = enabled;
         config.setBoolean(ServerConfig.Key.WHITELIST, whitelistEnabled);
+        config.save();
     }
 
     @Override

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1297,6 +1297,7 @@ public final class GlowServer implements Server {
     @Override
     public void setWhitelist(boolean enabled) {
         whitelistEnabled = enabled;
+        config.setBoolean(ServerConfig.Key.WHITELIST, whitelistEnabled);
     }
 
     @Override

--- a/src/main/java/net/glowstone/util/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/ServerConfig.java
@@ -64,6 +64,37 @@ public final class ServerConfig {
     }
 
     ////////////////////////////////////////////////////////////////////////////
+    // Value setters
+
+    private void set(String path, Object value) {
+        config.set(path, value);
+        try {
+            config.save(configFile);
+        } catch (IOException e) {
+            GlowServer.logger.log(Level.SEVERE, "Failed to write config: " + configFile, e);
+            return;
+        }
+    }
+
+    public void setString(Key key, String value) {
+        Validate.notNull(value);
+        parameters.put(key, value);
+        set(key.path, value);
+    }
+
+    public void setInt(Key key, int value) {
+        Validate.notNull(value);
+        parameters.put(key, value);
+        set(key.path, value);
+    }
+
+    public void setBoolean(Key key, boolean value) {
+        Validate.notNull(value);
+        parameters.put(key, value);
+        set(key.path, value);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
     // Value getters
 
     public String getString(Key key) {

--- a/src/main/java/net/glowstone/util/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/ServerConfig.java
@@ -1,5 +1,6 @@
 package net.glowstone.util;
 
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import net.glowstone.GlowServer;
 import org.apache.commons.lang.Validate;
 import org.bukkit.configuration.ConfigurationSection;
@@ -74,26 +75,13 @@ public final class ServerConfig {
         }
     }
 
-    ////////////////////////////////////////////////////////////////////////////
-    // Value setters
-
-    private void set(String path, Object value) {
-        config.set(path, value);
-    }
-
-    public void setString(Key key, String value) {
-        Validate.notNull(value);
-        set(key.path, value);
-    }
-
-    public void setInt(Key key, int value) {
-        Validate.notNull(value);
-        set(key.path, value);
-    }
-
-    public void setBoolean(Key key, boolean value) {
-        Validate.notNull(value);
-        set(key.path, value);
+    /**
+     * Function call sets runtime config information. For saving config to glowstone.yml, see {@link ServerConfig#save()}
+     * @param key the config key to write the value to
+     * @param value value to write to config key
+     */
+    public void set(Key key, Object value) {
+        config.set(key.path, value);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/util/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/ServerConfig.java
@@ -1,6 +1,5 @@
 package net.glowstone.util;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import net.glowstone.GlowServer;
 import org.apache.commons.lang.Validate;
 import org.bukkit.configuration.ConfigurationSection;

--- a/src/main/java/net/glowstone/util/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/ServerConfig.java
@@ -78,19 +78,16 @@ public final class ServerConfig {
 
     public void setString(Key key, String value) {
         Validate.notNull(value);
-        parameters.put(key, value);
         set(key.path, value);
     }
 
     public void setInt(Key key, int value) {
         Validate.notNull(value);
-        parameters.put(key, value);
         set(key.path, value);
     }
 
     public void setBoolean(Key key, boolean value) {
         Validate.notNull(value);
-        parameters.put(key, value);
         set(key.path, value);
     }
 

--- a/src/main/java/net/glowstone/util/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/ServerConfig.java
@@ -62,18 +62,23 @@ public final class ServerConfig {
 
         config.options().indent(4);
     }
-
     ////////////////////////////////////////////////////////////////////////////
-    // Value setters
+    // Save config
 
-    private void set(String path, Object value) {
-        config.set(path, value);
+    public void save() {
         try {
             config.save(configFile);
         } catch (IOException e) {
             GlowServer.logger.log(Level.SEVERE, "Failed to write config: " + configFile, e);
             return;
         }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Value setters
+
+    private void set(String path, Object value) {
+        config.set(path, value);
     }
 
     public void setString(Key key, String value) {


### PR DESCRIPTION
This PR fixes #491. It adds setters to ServerConfig, and uses those setters in GlowServer to set whitelist in Glowstone.yml.

---

_Edited by turt2live_

**Related Links:**
- Ticket: #491 
