### PR TITLE
Add space to console input

### DIFF
--- a/src/main/java/net/glowstone/ConsoleManager.java
+++ b/src/main/java/net/glowstone/ConsoleManager.java
@@ -174,7 +174,7 @@ public final class ConsoleManager {
             while (running) {
                 try {
                     if (jLine) {
-                        command = reader.readLine(">", null);
+                        command = reader.readLine("> ", null);
                     } else {
                         command = reader.readLine();
                     }


### PR DESCRIPTION
This is a simple change with a space at the end of the console reader. This is standard Bukkit and Minecraft behavior, and changes the session from this:

```
>whitelist off
whitelist off
11:55:52 [INFO] CONSOLE: Turned off white-listing
>toggledownfall
toggledownfall
11:55:55 [INFO] CONSOLE: Toggling downfall on for world 'world'
```

to this:

```
> whitelist off
whitelist off
11:55:52 [INFO] CONSOLE: Turned off white-listing
> toggledownfall
toggledownfall
11:55:55 [INFO] CONSOLE: Toggling downfall on for world 'world'
```

Also first actual PR, and fittingly so for something so trivial.

**EDIT**: SpaceManiac, dequis, and I have tested and confirmed that this is in fact _not_ standard behavior in CraftBukkit, Spigot, or the Minecraft server. Still, it does increase readability.
