### PR TITLE
Fix the player 'joining' when they should be kicked

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -743,7 +743,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public boolean isOnline() {
-        return session.isActive();
+        return session.isActive() && session.isOnline();
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -123,7 +123,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
     /**
      * The time the player joined.
      */
-    private final long joinTime;
+    private long joinTime;
 
     /**
      * The settings sent by the client.
@@ -267,6 +267,23 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         session.send(new LoginSuccessMessage(profile.getUniqueId().toString(), profile.getName()));
         session.setProtocol(ProtocolType.PLAY);
 
+        // read data from player reader
+        hasPlayedBefore = reader.hasPlayedBefore();
+        if (hasPlayedBefore) {
+            firstPlayed = reader.getFirstPlayed();
+            lastPlayed = reader.getLastPlayed();
+            bedSpawn = reader.getBedSpawnLocation();
+        } else {
+            firstPlayed = 0;
+            lastPlayed = 0;
+        }
+
+        //creates InventoryMonitor to avoid NullPointerException
+        invMonitor = new InventoryMonitor(getOpenInventory());
+        updateInventory(); // send inventory contents
+    }
+
+    public void join(GlowSession session, PlayerDataService.PlayerReader reader) {
         // send join game
         // in future, handle hardcore, difficulty, and level type
         String type = world.getWorldType().getName().toLowerCase();
@@ -281,16 +298,6 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         session.send(PluginMessage.fromString("MC|Brand", server.getName()));
         sendSupportedChannels();
 
-        // read data from player reader
-        hasPlayedBefore = reader.hasPlayedBefore();
-        if (hasPlayedBefore) {
-            firstPlayed = reader.getFirstPlayed();
-            lastPlayed = reader.getLastPlayed();
-            bedSpawn = reader.getBedSpawnLocation();
-        } else {
-            firstPlayed = 0;
-            lastPlayed = 0;
-        }
         joinTime = System.currentTimeMillis();
         reader.readData(this);
         reader.close();
@@ -305,9 +312,6 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         sendRainDensity();
         sendSkyDarkness();
         sendAbilities();
-
-        invMonitor = new InventoryMonitor(getOpenInventory());
-        updateInventory(); // send inventory contents
 
         // send initial location
         session.send(new PositionRotationMessage(location));

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -69,6 +69,10 @@ public final class GlowSession extends BasicSession {
     private InetSocketAddress address;
 
     /**
+     * The state of the connection
+     */
+    private boolean online = false;
+    /**
      * The verify token used in authentication
      */
     private byte[] verifyToken;
@@ -243,6 +247,14 @@ public final class GlowSession extends BasicSession {
     // Player and state management
 
     /**
+     * Get session online state
+     * @return true if this session's state is online
+     */
+    public boolean isOnline() {
+        return online;
+    }
+
+    /**
      * Gets the player associated with this session.
      * @return The player, or {@code null} if no player is associated with it.
      */
@@ -297,6 +309,8 @@ public final class GlowSession extends BasicSession {
         }
 
         player.getWorld().getRawPlayers().add(player);
+
+        online = true;
 
         GlowServer.logger.info(player.getName() + " [" + address + "] connected, UUID: " + player.getUniqueId());
 
@@ -363,7 +377,7 @@ public final class GlowSession extends BasicSession {
 
             reason = event.getReason();
 
-            if (event.getLeaveMessage() != null) {
+            if (player.isOnline() && event.getLeaveMessage() != null) {
                 server.broadcastMessage(event.getLeaveMessage());
             }
         }
@@ -482,10 +496,8 @@ public final class GlowSession extends BasicSession {
         GlowServer.logger.info(player.getName() + " [" + address + "] lost connection");
 
         final String text = EventFactory.onPlayerQuit(player).getQuitMessage();
-        if (player.isOnline()) {
-            if (text != null && !text.isEmpty()) {
-                server.broadcastMessage(text);
-            }
+        if (online && text != null && !text.isEmpty()) {
+            server.broadcastMessage(text);
         }
 
         player = null; // in case we are disposed twice

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -285,6 +285,9 @@ public final class GlowSession extends BasicSession {
             return;
         }
 
+        //joins the player
+        player.join(this, reader);
+
         // Kick other players with the same UUID
         for (GlowPlayer other : getServer().getOnlinePlayers()) {
             if (other != player && other.getUniqueId().equals(player.getUniqueId())) {
@@ -479,8 +482,10 @@ public final class GlowSession extends BasicSession {
         GlowServer.logger.info(player.getName() + " [" + address + "] lost connection");
 
         final String text = EventFactory.onPlayerQuit(player).getQuitMessage();
-        if (text != null && !text.isEmpty()) {
-            server.broadcastMessage(text);
+        if (player.isOnline()) {
+            if (text != null && !text.isEmpty()) {
+                server.broadcastMessage(text);
+            }
         }
 
         player = null; // in case we are disposed twice


### PR DESCRIPTION
ORIGINALLY PR #518

This PR fixes issue #510, and #156, as well as touches on issues addressed in PR #373 about errors when not on a server whitelist.

The PR moves the method calls that send the join packet to the player from the constructor to a seperate method, and then calls that method once the player has been confirmed, and the PlayerLoginEvent has not been disallowed.

The creation of the InventoryMonitor is necessary in order to prevent errors with pulse.

---

_Edited by turt2live_

**Related Links:**
- Original PR: #518 
- Ticket: #510 
- Ticket: #156 
- Ticket: #296 
- Includes changes from #373
