### PR TITLE
Do not reassign entity ids on world changes / respawns

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -5,6 +5,7 @@ import io.netty.channel.ChannelFuture;
 import net.glowstone.command.ColorCommand;
 import net.glowstone.command.TellrawCommand;
 import net.glowstone.constants.GlowPotionEffect;
+import net.glowstone.entity.EntityIdManager;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.inventory.CraftingManager;
 import net.glowstone.inventory.GlowInventory;
@@ -271,6 +272,11 @@ public final class GlowServer implements Server {
      * The BanList for IP addresses.
      */
     private final GlowBanList ipBans;
+
+    /**
+     * The EntityIdManager for this server.
+     */
+    private final EntityIdManager entityIdManager = new EntityIdManager();
 
     /**
      * The world this server is managing.
@@ -694,6 +700,14 @@ public final class GlowServer implements Server {
      */
     public SessionRegistry getSessionRegistry() {
         return sessions;
+    }
+
+    /**
+     * Gets the entity id manager.
+     * @return The {@link EntityIdManager}.
+     */
+    public EntityIdManager getEntityIdManager() {
+        return entityIdManager;
     }
 
     /**

--- a/src/main/java/net/glowstone/entity/EntityIdManager.java
+++ b/src/main/java/net/glowstone/entity/EntityIdManager.java
@@ -1,0 +1,61 @@
+package net.glowstone.entity;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A class which manages all entity ids.
+ * This is the class responsible for allocating/deallocating entity ids on a server.
+ */
+public final class EntityIdManager {
+
+    /**
+     * A set containing all used entity ids.
+     */
+    private final Set<Integer> usedIds = new HashSet<>();
+
+    /**
+     * The last assigned id value.
+     */
+    private int lastId = 0;
+
+    /**
+     * Allocates the id for an entity.
+     * This method performs synchronization as it might be
+     * accessed by multiple world threads simultaneously.
+     * @param entity The entity.
+     * @return The id.
+     */
+    synchronized int allocate(GlowEntity entity) {
+        if (entity.id != 0) {
+            throw new IllegalStateException("Entity already has an id assigned.");
+        }
+
+        int startedAt = lastId;
+        // intentionally wraps around integer boundaries
+        for (int id = lastId + 1; id != startedAt; ++id) {
+            // skip special values
+            if (id == -1 || id == 0) continue;
+
+            if (usedIds.add(id)) {
+                entity.id = id;
+                lastId = id;
+                return id;
+            }
+        }
+
+        throw new IllegalStateException("No free entity ids");
+    }
+
+    /**
+     * Deallocates the id for an entity.
+     * @param entity The entity.
+     */
+    synchronized void deallocate(GlowEntity entity) {
+        if (entity.id == 0) {
+            throw new IllegalStateException("Entity does not have an id assigned.");
+        }
+        usedIds.remove(entity.id);
+    }
+
+}

--- a/src/main/java/net/glowstone/entity/EntityManager.java
+++ b/src/main/java/net/glowstone/entity/EntityManager.java
@@ -23,11 +23,6 @@ public final class EntityManager implements Iterable<GlowEntity> {
     private final Map<Class<? extends GlowEntity>, Set<? extends GlowEntity>> groupedEntities = new HashMap<>();
 
     /**
-     * The last assigned id value.
-     */
-    private int lastId = 0;
-
-    /**
      * Gets all entities with the specified type.
      * @param type The {@link Class} for the type.
      * @param <T> The type of entity.
@@ -61,40 +56,24 @@ public final class EntityManager implements Iterable<GlowEntity> {
     }
 
     /**
-     * Allocates the id for an entity.
+     * Registers the entity to this world.
      * @param entity The entity.
-     * @return The id.
      */
-    int allocate(GlowEntity entity) {
-        int startedAt = lastId;
-        // intentionally wraps around integer boundaries
-        for (int id = lastId + 1; id != startedAt; ++id) {
-            // skip special values
-            if (id == -1 || id == 0) continue;
-
-            if (!entities.containsKey(id)) {
-                allocate(entity, id);
-                return id;
-            }
-        }
-
-        throw new IllegalStateException("No free entity ids");
-    }
-
     @SuppressWarnings("unchecked")
-    private void allocate(GlowEntity entity, int id) {
-        entity.id = id;
-        entities.put(id, entity);
+    void register(GlowEntity entity) {
+        if (entity.id == 0) {
+            throw new IllegalStateException("Entity has not been assigned an id.");
+        }
+        entities.put(entity.id, entity);
         ((Collection<GlowEntity>) getAll(entity.getClass())).add(entity);
         ((GlowChunk) entity.location.getChunk()).getRawEntities().add(entity);
-        lastId = id;
     }
 
     /**
-     * Deallocates the id for an entity.
+     * Unregister the entity to this world.
      * @param entity The entity.
      */
-    void deallocate(GlowEntity entity) {
+    void unregister(GlowEntity entity) {
         entities.remove(entity.id);
         getAll(entity.getClass()).remove(entity);
         ((GlowChunk) entity.location.getChunk()).getRawEntities().remove(entity);

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -141,7 +141,8 @@ public abstract class GlowEntity implements Entity {
         this.location = location.clone();
         this.world = (GlowWorld) location.getWorld();
         this.server = world.getServer();
-        world.getEntityManager().allocate(this);
+        server.getEntityIdManager().allocate(this);
+        world.getEntityManager().register(this);
         previousLocation = location.clone();
     }
 
@@ -246,9 +247,9 @@ public abstract class GlowEntity implements Entity {
     @Override
     public boolean teleport(Location location) {
         if (location.getWorld() != world) {
-            world.getEntityManager().deallocate(this);
+            world.getEntityManager().unregister(this);
             world = (GlowWorld) location.getWorld();
-            world.getEntityManager().allocate(this);
+            world.getEntityManager().register(this);
         }
         setRawLocation(location);
         teleported = true;
@@ -576,7 +577,8 @@ public abstract class GlowEntity implements Entity {
     @Override
     public void remove() {
         active = false;
-        world.getEntityManager().deallocate(this);
+        world.getEntityManager().unregister(this);
+        server.getEntityIdManager().deallocate(this);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -579,9 +579,9 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
     private void spawnAt(Location location) {
         // switch worlds
         GlowWorld oldWorld = world;
-        world.getEntityManager().deallocate(this);
+        world.getEntityManager().unregister(this);
         world = (GlowWorld) location.getWorld();
-        world.getEntityManager().allocate(this);
+        world.getEntityManager().register(this);
 
         // switch chunk set
         // no need to send chunk unload messages - respawn unloads all chunks
@@ -629,6 +629,15 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         // fire event and perform spawn
         PlayerRespawnEvent event = new PlayerRespawnEvent(this, dest, spawnAtBed);
         EventFactory.callEvent(event);
+        if (event.getRespawnLocation().getWorld() == location.getWorld() && knownEntities.size() > 0) {
+            // we need to manually reset all known entities if the player respawns in the same world
+            List<Integer> entityIds = new ArrayList<>(knownEntities.size());
+            for (GlowEntity e : knownEntities) {
+                entityIds.add(e.getEntityId());
+            }
+            session.send(new DestroyEntitiesMessage(entityIds));
+            knownEntities.clear();
+        }
         spawnAt(event.getRespawnLocation());
 
         // just in case any items are left in their inventory after they respawn

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -405,7 +405,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         for (Iterator<Map.Entry<GlowEntity, Integer>> it = knownEntities.entrySet().iterator(); it.hasNext(); ) {
             Map.Entry<GlowEntity, Integer> entry = it.next();
             GlowEntity entity = entry.getKey();
-            if (isWithinDistance(entity)) {
+            if (isWithinDistance(entity) && entity.getEntityId() == entry.getValue()) {
                 for (Message msg : entity.createUpdateMessage()) {
                     session.send(msg);
                 }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -629,7 +629,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         // fire event and perform spawn
         PlayerRespawnEvent event = new PlayerRespawnEvent(this, dest, spawnAtBed);
         EventFactory.callEvent(event);
-        if (event.getRespawnLocation().getWorld() == location.getWorld() && knownEntities.size() > 0) {
+        if (event.getRespawnLocation().getWorld().equals(getWorld()) && knownEntities.size() > 0) {
             // we need to manually reset all known entities if the player respawns in the same world
             List<Integer> entityIds = new ArrayList<>(knownEntities.size());
             for (GlowEntity e : knownEntities) {

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -405,7 +405,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         for (Iterator<Map.Entry<GlowEntity, Integer>> it = knownEntities.entrySet().iterator(); it.hasNext(); ) {
             Map.Entry<GlowEntity, Integer> entry = it.next();
             GlowEntity entity = entry.getKey();
-            if (isWithinDistance(entity) && entity.getEntityId() == entry.getValue()) {
+            if (isWithinDistance(entity)) {
                 for (Message msg : entity.createUpdateMessage()) {
                     session.send(msg);
                 }


### PR DESCRIPTION
This PR fixes a bug caused by when teleporting entities to other worlds due to which entities are displayed multiple times to the clients.
This is also the cause for players hanging around after death which is also fixed with this PR.
Entities near the respawn location being invisible is also fixed with this PR.
**Current behavior**
Entity ids are allocated on a per world basis in the `EntityManager` and are reassigned if entities change the world or players respawn. This leads to the old id not being removed and artifacts being created. Furthermore the entity id should not change at all (due to CraftBukkit compatibility).
**New behaviour**
Entity ids are now allocated in the `EntityIdManager` of which only a single instance exists per server. This allows the entity to change its world without being reassigned  to a new id by the `EntityManager` of the new world.
This PR also resets all known entities when a player respawns in the same world. This causes all entities to be resend after the respawn which solves the third issue.

**Related Links:**
- Ticket: #486 
- Ticket: #447 
