### PR TITLE
Use a view for GlowServer.getOnlinePlayers()

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -22,6 +22,7 @@ import net.glowstone.scheduler.WorldScheduler;
 import net.glowstone.util.*;
 import net.glowstone.util.bans.GlowBanList;
 import net.glowstone.util.bans.UuidListFile;
+import org.apache.commons.lang.Validate;
 import org.bukkit.*;
 import org.bukkit.World.Environment;
 import org.bukkit.command.*;
@@ -368,6 +369,15 @@ public final class GlowServer implements Server {
      * The server port.
      */
     private int port;
+    /**
+     * A set of all online players.
+     */
+    private final Set<GlowPlayer> onlinePlayers = new HashSet<>();
+
+    /**
+     * A view of all online players.
+     */
+    private final Set<GlowPlayer> onlineView = Collections.unmodifiableSet(onlinePlayers);
 
     /**
      * Creates a new server.
@@ -886,6 +896,20 @@ public final class GlowServer implements Server {
         return config.getBoolean(ServerConfig.Key.ANNOUNCE_ACHIEVEMENTS);
     }
 
+    /**
+     * Sets a player as being online internally
+     * @param player
+     */
+    public void setPlayerOnline(GlowPlayer player) {
+        Validate.notNull(player);
+        onlinePlayers.add(player);
+    }
+
+    public void setPlayerOffline(GlowPlayer player) {
+        Validate.notNull(player);
+        onlinePlayers.remove(player);
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Static server properties
 
@@ -1037,14 +1061,7 @@ public final class GlowServer implements Server {
 
     @Override
     public Collection<GlowPlayer> getOnlinePlayers() {
-        // todo: provide a view instead of reassembling the list each time
-        ArrayList<GlowPlayer> result = new ArrayList<>();
-        for (GlowWorld world : worlds.getWorlds()) {
-            for (GlowPlayer player : world.getRawPlayers()) {
-                result.add(player);
-            }
-        }
-        return result;
+        return onlineView;
     }
 
     @Override

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -898,16 +898,16 @@ public final class GlowServer implements Server {
 
     /**
      * Sets a player as being online internally
-     * @param player
+     * @param player player to set online/offline
+     * @param online whether the player is online or offline
      */
-    public void setPlayerOnline(GlowPlayer player) {
+    public void setPlayerOnline(GlowPlayer player, boolean online) {
         Validate.notNull(player);
-        onlinePlayers.add(player);
-    }
-
-    public void setPlayerOffline(GlowPlayer player) {
-        Validate.notNull(player);
-        onlinePlayers.remove(player);
+        if (online) {
+            onlinePlayers.add(player);
+        } else {
+            onlinePlayers.remove(player);
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -295,6 +295,9 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         reader.readData(this);
         reader.close();
 
+        // Add player to list of online players
+        getServer().setPlayerOnline(this);
+
         // save data back out
         saveData();
 
@@ -370,6 +373,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         getInventory().removeViewer(this);
         getInventory().getCraftingInventory().removeViewer(this);
         permissions.clearPermissions();
+        getServer().setPlayerOffline(this);
         super.remove();
     }
 

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -296,7 +296,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         reader.close();
 
         // Add player to list of online players
-        getServer().setPlayerOnline(this);
+        getServer().setPlayerOnline(this, true);
 
         // save data back out
         saveData();
@@ -373,7 +373,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         getInventory().removeViewer(this);
         getInventory().getCraftingInventory().removeViewer(this);
         permissions.clearPermissions();
-        getServer().setPlayerOffline(this);
+        getServer().setPlayerOnline(this, false);
         super.remove();
     }
 


### PR DESCRIPTION
As it stands, whenever a call to `getOnlinePlayers()` is made, it loops over all worlds and adds players to a list. While this behaviour works, it is not at all efficient (hence the TODO). The JavaDocs also say that this will be a view, not a new collection.

I have created `SuperCollection`, which is a wrapper around Guava's `Iterables.concat()` which iterates over each `Iterable` it is passed.

This works thanks to the logic in `EntityManager`, which keeps a Map of entity type to collection of those entities - which is directly piped into the view. I've also made the collection unmodifiable, so that a plugin cannot break the server internals.
