### PR TITLE
[WIP] Fixed problems with adding air to player inventory

### DIFF
--- a/src/main/java/net/glowstone/inventory/GlowInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowInventory.java
@@ -223,6 +223,7 @@ public class GlowInventory implements Inventory {
         for (int i = 0; i < items.length; ++i) {
             ItemStack item = ItemStack.sanitize(items[i]);
 
+            //fail silently on invalid item
             if (item == null) continue;
 
             while (item.getAmount() > 0) {
@@ -233,18 +234,19 @@ public class GlowInventory implements Inventory {
                     break;
                 } else {
                     ItemStack curItem = getItem(available);
-                    int fill = item.getAmount();
-                    if (curItem == null) {
-                        ItemStack temp = new ItemStack(item);
-                        fill = item.getAmount() >= getMaxStackSize() ? getMaxStackSize() : item.getAmount();
-                        temp.setAmount(fill);
-                        setItem(available, temp);
+
+                    int curAmount = curItem == null ? 0 : curItem.getAmount();
+                    int add;
+
+                    if (curAmount + item.getAmount() >= item.getMaxStackSize()) {
+                        add = item.getMaxStackSize() - curAmount;
                     } else {
-                        fill = item.getAmount() + curItem.getAmount() >= curItem.getMaxStackSize()
-                                ? curItem.getMaxStackSize() : curItem.getAmount() + item.getAmount();
-                        curItem.setAmount(fill);
+                        add = item.getAmount();
                     }
-                    item.setAmount(item.getAmount() - fill);
+
+                    ItemStack temp = new ItemStack(item.getType(), curAmount + add);
+                    setItem(available, temp);
+                    item.setAmount(item.getAmount() - add);
                 }
             }
         }

--- a/src/main/java/net/glowstone/inventory/GlowInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowInventory.java
@@ -235,7 +235,7 @@ public class GlowInventory implements Inventory {
                     ItemStack curItem = getItem(available);
                     int fill = item.getAmount();
                     if (curItem == null) {
-                        ItemStack temp = item.clone();
+                        ItemStack temp = new ItemStack(item);
                         fill = item.getAmount() >= getMaxStackSize() ? getMaxStackSize() : item.getAmount();
                         temp.setAmount(fill);
                         setItem(available, temp);

--- a/src/main/java/net/glowstone/inventory/GlowInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowInventory.java
@@ -221,42 +221,49 @@ public class GlowInventory implements Inventory {
         HashMap<Integer, ItemStack> result = new HashMap<>();
 
         for (int i = 0; i < items.length; ++i) {
-            ItemStack item = ItemIds.sanitize(items[i]);
-            if (item == null) continue; // invalid items fail silently
-            int maxStackSize = item.getType() == null ? 64 : item.getType().getMaxStackSize();
-            int toAdd = item.getAmount();
+            ItemStack item = ItemStack.sanitize(items[i]);
 
-            for (int j = 0; toAdd > 0 && j < getSize(); ++j) {
-                // Look for existing stacks to add to
-                if (slots[j] != null && slots[j].isSimilar(item)) {
-                    int space = maxStackSize - slots[j].getAmount();
-                    if (space < 0) continue;
-                    if (space > toAdd) space = toAdd;
+            if (item == null) continue;
 
-                    slots[j].setAmount(slots[j].getAmount() + space);
-                    toAdd -= space;
-                }
-            }
+            while (item.getAmount() > 0) {
+                int available = firstAvailable(item);
 
-            if (toAdd > 0) {
-                // Look for empty slots to add to
-                for (int j = 0; toAdd > 0 && j < getSize(); ++j) {
-                    if (slots[j] == null) {
-                        int num = toAdd > maxStackSize ? maxStackSize : toAdd;
-                        slots[j] = item.clone();
-                        slots[j].setAmount(num);
-                        toAdd -= num;
+                if (available == -1) {
+                    result.put(i, item);
+                    break;
+                } else {
+                    ItemStack curItem = getItem(available);
+                    int fill = item.getAmount();
+                    if (curItem == null) {
+                        ItemStack temp = item.clone();
+                        fill = item.getAmount() >= getMaxStackSize() ? getMaxStackSize() : item.getAmount();
+                        temp.setAmount(fill);
+                        setItem(available, temp);
+                    } else {
+                        fill = item.getAmount() + curItem.getAmount() >= curItem.getMaxStackSize()
+                                ? curItem.getMaxStackSize() : curItem.getAmount() + item.getAmount();
+                        curItem.setAmount(fill);
                     }
+                    item.setAmount(item.getAmount() - fill);
                 }
-            }
-
-            if (toAdd > 0) {
-                // Still couldn't stash them all.
-                result.put(i, item.clone());
             }
         }
 
         return result;
+    }
+
+    public int firstAvailable(ItemStack item) {
+        ItemStack[] inventory = getContents();
+        if (item == null) {
+            return -1;
+        }
+        for (int i = 0; i < inventory.length; ++i) {
+            ItemStack curItem = inventory[i];
+            if (curItem == null || (curItem.isSimilar(item) && curItem.getAmount() < curItem.getMaxStackSize())) {
+                return i;
+            }
+        }
+        return firstEmpty();
     }
 
     @Override


### PR DESCRIPTION
The PR fixes #104, although the massive error could not be reproduced on a clean master. This PR rewrites the addItem code to make it cleaner and more structured.

Essentially, air has a max stack size of 0, so when added using the old algorithm it would fill every single open spot with air. When this was loaded from NBT, all the air occupied index 0, replacing the 0<sup>th</sup> element. Instead, air not only occupies solely the first spot, but addItems now mimics craftbukkit functionality in stacking, and replaces air with null.
