### PR TITLE
Cacti hurt when hugged

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -513,6 +513,25 @@ public abstract class GlowEntity implements Entity {
         return true;
     }
 
+    /**
+     *
+     * @param material to check if the player is buy
+     * @return if the player is near material or not
+     */
+    public boolean isTouchingMaterial(Material material) {
+
+        BlockFace[] sides = {BlockFace.EAST, BlockFace.WEST, BlockFace.SOUTH, BlockFace.NORTH, BlockFace.UP, BlockFace.SELF,
+                BlockFace.NORTH_EAST, BlockFace.NORTH_WEST,  BlockFace.SOUTH_EAST, BlockFace.SOUTH_WEST};
+
+        //todo: This isnt the most accurate way. A more accurate one can be made once entity support is finished
+        //uses a bounding box
+        for (BlockFace face : sides) {
+            if (getLocation().getBlock().getRelative(face).getType() == material)
+                return true;
+        }
+        return false;
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Various properties
 

--- a/src/main/java/net/glowstone/entity/GlowHumanEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowHumanEntity.java
@@ -275,7 +275,7 @@ public abstract class GlowHumanEntity extends GlowLivingEntity implements HumanE
 
     @Override
     protected boolean canTakeDamage(EntityDamageEvent.DamageCause damageCause) {
-        return gameMode == GameMode.SURVIVAL || gameMode == GameMode.ADVENTURE && super.canTakeDamage(damageCause);
+        return (gameMode == GameMode.SURVIVAL || gameMode == GameMode.ADVENTURE) && super.canTakeDamage(damageCause);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/entity/GlowHumanEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowHumanEntity.java
@@ -12,6 +12,7 @@ import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.Inventory;
@@ -273,8 +274,8 @@ public abstract class GlowHumanEntity extends GlowLivingEntity implements HumanE
     // Health
 
     @Override
-    protected boolean canTakeDamage() {
-        return gameMode == GameMode.SURVIVAL || gameMode == GameMode.ADVENTURE;
+    protected boolean canTakeDamage(EntityDamageEvent.DamageCause damageCause) {
+        return gameMode == GameMode.SURVIVAL || gameMode == GameMode.ADVENTURE && super.canTakeDamage(damageCause);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/entity/GlowHumanEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowHumanEntity.java
@@ -381,4 +381,9 @@ public abstract class GlowHumanEntity extends GlowLivingEntity implements HumanE
             ((GlowInventory) inventory).removeViewer(this);
         }
     }
+
+    @Override
+    public boolean canTakeCactusDamage() {
+        return gameMode == GameMode.SURVIVAL || gameMode == GameMode.ADVENTURE;
+    }
 }

--- a/src/main/java/net/glowstone/entity/GlowHumanEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowHumanEntity.java
@@ -273,7 +273,7 @@ public abstract class GlowHumanEntity extends GlowLivingEntity implements HumanE
     // Health
 
     @Override
-    protected boolean canDrown() {
+    protected boolean canTakeDamage() {
         return gameMode == GameMode.SURVIVAL || gameMode == GameMode.ADVENTURE;
     }
 
@@ -380,10 +380,5 @@ public abstract class GlowHumanEntity extends GlowLivingEntity implements HumanE
         if (inventory instanceof GlowInventory) {
             ((GlowInventory) inventory).removeViewer(this);
         }
-    }
-
-    @Override
-    public boolean canTakeCactusDamage() {
-        return gameMode == GameMode.SURVIVAL || gameMode == GameMode.ADVENTURE;
     }
 }

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -483,16 +483,16 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
         // Gets the block the are standing on and the location of it
         Material blockBelow = getLocation().getBlock().getType();
-        Location blockLocationX = getLocation().getBlock().getLocation();
-        Location blockLocationNegX = getLocation().getBlock().getLocation();
-        Location blockLocationZ = getLocation().getBlock().getLocation();
-        Location blockLocationNegZ = getLocation().getBlock().getLocation();
+        Location blockLocationX = getLocation();
+        Location blockLocationNegX = getLocation();
+        Location blockLocationZ = getLocation();
+        Location blockLocationNegZ = getLocation();
 
         // sets the location to its respective cord
-        blockLocationX.setX(blockLocationX.getX() + 1);
-        blockLocationNegX.setX(blockLocationNegX.getX() - 1);
-        blockLocationZ.setZ(blockLocationZ.getZ() + 1);
-        blockLocationNegZ.setZ(blockLocationNegZ.getZ() - 1);
+        blockLocationX.add(1, 0, 0);
+        blockLocationNegX.subtract(1, 0, 0);
+        blockLocationZ.add(0, 0, 1);
+        blockLocationNegZ.subtract(0, 0, 1);
 
         //Checks if the living entity is near a cactus or is on top of a cactus and hurts them
         if ((blockBelow == Material.CACTUS || blockLocationX.getBlock().getType() == Material.CACTUS ||

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -66,7 +66,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     /**
      * The default length of the invincibility period.
      */
-    private int maxNoDamageTicks = 20;
+    private int maxNoDamageTicks = 10;
 
     /**
      * A custom overhead name to be shown for non-Players.

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -647,5 +647,4 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     public boolean setLeashHolder(Entity holder) {
         return false;
     }
-
 }

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -10,6 +10,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.*;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
@@ -476,24 +477,16 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
     public void takeCactusDamage() {
 
-        // Gets the block the are standing on and the location of it
-        Material blockBelow = getLocation().getBlock().getType();
-        Location blockLocationX = getLocation();
-        Location blockLocationNegX = getLocation();
-        Location blockLocationZ = getLocation();
-        Location blockLocationNegZ = getLocation();
-
-        // sets the location to its respective cord
-        blockLocationX.add(1, 0, 0);
-        blockLocationNegX.subtract(1, 0, 0);
-        blockLocationZ.add(0, 0, 1);
-        blockLocationNegZ.subtract(0, 0, 1);
+        BlockFace[] sides = {BlockFace.EAST, BlockFace.WEST, BlockFace.SOUTH, BlockFace.NORTH, BlockFace.UP, BlockFace.SELF};
 
         //Checks if the living entity is near a cactus or is on top of a cactus and hurts them
-        if ((blockBelow == Material.CACTUS || blockLocationX.getBlock().getType() == Material.CACTUS ||
-                blockLocationNegX.getBlock().getType() == Material.CACTUS || blockLocationZ.getBlock().getType() == Material.CACTUS ||
-                blockLocationNegZ.getBlock().getType() == Material.CACTUS) && canTakeDamage()) {
-            damage(1, EntityDamageEvent.DamageCause.CONTACT);
+        for (BlockFace face : sides) {
+            if (getLocation().getBlock().getRelative(face).getType() == Material.CACTUS && canTakeDamage()) {
+
+                damage(1, EntityDamageEvent.DamageCause.CONTACT);
+
+            }
+
         }
 
     }

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -119,7 +119,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         Material mat = getEyeLocation().getBlock().getType();
         // breathing
         if (mat == Material.WATER || mat == Material.STATIONARY_WATER) {
-            if (canTakeDamage()) {
+            if (canTakeDamage(EntityDamageEvent.DamageCause.DROWNING)) {
                 --airTicks;
                 if (airTicks <= -20) {
                     airTicks = 0;
@@ -130,7 +130,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             airTicks = maximumAir;
         }
 
-        if (isTouchingMaterial(Material.CACTUS) && canTakeDamage())
+        if (isTouchingMaterial(Material.CACTUS) && canTakeDamage(EntityDamageEvent.DamageCause.CONTACT))
             damage(1, EntityDamageEvent.DamageCause.CONTACT);
 
         // potion effects
@@ -283,7 +283,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
      * Get whether this entity should take damage.
      * @return whether this entity can take damage.
      */
-    protected boolean canTakeDamage() {
+    protected boolean canTakeDamage(EntityDamageEvent.DamageCause damageCause) {
         return true;
     }
 

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -477,7 +477,9 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
     public void takeCactusDamage() {
 
-        BlockFace[] sides = {BlockFace.EAST, BlockFace.WEST, BlockFace.SOUTH, BlockFace.NORTH, BlockFace.UP, BlockFace.SELF};
+        BlockFace[] sides = {BlockFace.EAST, BlockFace.WEST, BlockFace.SOUTH, BlockFace.NORTH, BlockFace.UP, BlockFace.SELF,
+                BlockFace.NORTH_EAST, BlockFace.NORTH_WEST,  BlockFace.SOUTH_EAST, BlockFace.SOUTH_WEST};
+
 
         //Checks if the living entity is near a cactus or is on top of a cactus and hurts them
         for (BlockFace face : sides) {

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -119,7 +119,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         Material mat = getEyeLocation().getBlock().getType();
         // breathing
         if (mat == Material.WATER || mat == Material.STATIONARY_WATER) {
-            if (canDrown()) {
+            if (canTakeDamage()) {
                 --airTicks;
                 if (airTicks <= -20) {
                     airTicks = 0;
@@ -282,7 +282,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
      * Get whether this entity should take drowning damage.
      * @return whether this entity can drown
      */
-    protected boolean canDrown() {
+    protected boolean canTakeDamage() {
         return true;
     }
 
@@ -474,11 +474,6 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         lastDamage = damage;
     }
 
-
-    public boolean canTakeCactusDamage() {
-        return true;
-    }
-
     public void takeCactusDamage() {
 
         // Gets the block the are standing on and the location of it
@@ -497,7 +492,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         //Checks if the living entity is near a cactus or is on top of a cactus and hurts them
         if ((blockBelow == Material.CACTUS || blockLocationX.getBlock().getType() == Material.CACTUS ||
                 blockLocationNegX.getBlock().getType() == Material.CACTUS || blockLocationZ.getBlock().getType() == Material.CACTUS ||
-                blockLocationNegZ.getBlock().getType() == Material.CACTUS) && canTakeCactusDamage()) {
+                blockLocationNegZ.getBlock().getType() == Material.CACTUS) && canTakeDamage()) {
             damage(1, EntityDamageEvent.DamageCause.CONTACT);
         }
 

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -10,7 +10,6 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.entity.*;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
@@ -474,19 +473,6 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     @Override
     public void setLastDamage(double damage) {
         lastDamage = damage;
-    }
-
-    public boolean isTouchingMaterial(Material material) {
-
-        BlockFace[] sides = {BlockFace.EAST, BlockFace.WEST, BlockFace.SOUTH, BlockFace.NORTH, BlockFace.UP, BlockFace.SELF,
-                BlockFace.NORTH_EAST, BlockFace.NORTH_WEST,  BlockFace.SOUTH_EAST, BlockFace.SOUTH_WEST};
-
-        //Checks if the living entity is near a cactus or is on top of a cactus and hurts them
-        for (BlockFace face : sides) {
-            if (getLocation().getBlock().getRelative(face).getType() == material)
-            return true;
-        }
-        return false;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -131,7 +131,8 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             airTicks = maximumAir;
         }
 
-        takeDamageWhenHugged(Material.CACTUS);
+        if (isTouchingMaterial(Material.CACTUS) && canTakeDamage())
+            damage(1, EntityDamageEvent.DamageCause.CONTACT);
 
         // potion effects
         List<PotionEffect> effects = new ArrayList<>(potionEffects.values());
@@ -280,8 +281,8 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     }
 
     /**
-     * Get whether this entity should take drowning damage.
-     * @return whether this entity can drown
+     * Get whether this entity should take damage.
+     * @return whether this entity can take damage.
      */
     protected boolean canTakeDamage() {
         return true;
@@ -475,22 +476,17 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         lastDamage = damage;
     }
 
-    public void takeDamageWhenHugged(Material material) {
+    public boolean isTouchingMaterial(Material material) {
 
         BlockFace[] sides = {BlockFace.EAST, BlockFace.WEST, BlockFace.SOUTH, BlockFace.NORTH, BlockFace.UP, BlockFace.SELF,
                 BlockFace.NORTH_EAST, BlockFace.NORTH_WEST,  BlockFace.SOUTH_EAST, BlockFace.SOUTH_WEST};
 
         //Checks if the living entity is near a cactus or is on top of a cactus and hurts them
         for (BlockFace face : sides) {
-            if (getLocation().getBlock().getRelative(face).getType() == material && canTakeDamage()) {
-
-                damage(1, EntityDamageEvent.DamageCause.CONTACT);
-
-
-            }
-
+            if (getLocation().getBlock().getRelative(face).getType() == material)
+            return true;
         }
-
+        return false;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -130,6 +130,8 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             airTicks = maximumAir;
         }
 
+        takeCactusDamage();
+
         // potion effects
         List<PotionEffect> effects = new ArrayList<>(potionEffects.values());
         for (PotionEffect effect : effects) {
@@ -395,6 +397,8 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         // invincibility timer
         if (noDamageTicks > 0 || health <= 0) {
             return;
+        } else {
+            noDamageTicks = maxNoDamageTicks;
         }
 
         // fire resistance
@@ -468,6 +472,35 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     @Override
     public void setLastDamage(double damage) {
         lastDamage = damage;
+    }
+
+
+    public boolean canTakeCactusDamage() {
+        return true;
+    }
+
+    public void takeCactusDamage() {
+
+        // Gets the block the are standing on and the location of it
+        Material blockBelow = getLocation().getBlock().getType();
+        Location blockLocationX = getLocation().getBlock().getLocation();
+        Location blockLocationNegX = getLocation().getBlock().getLocation();
+        Location blockLocationZ = getLocation().getBlock().getLocation();
+        Location blockLocationNegZ = getLocation().getBlock().getLocation();
+
+        // sets the location to its respective cord
+        blockLocationX.setX(blockLocationX.getX() + 1);
+        blockLocationNegX.setX(blockLocationNegX.getX() - 1);
+        blockLocationZ.setZ(blockLocationZ.getZ() + 1);
+        blockLocationNegZ.setZ(blockLocationNegZ.getZ() - 1);
+
+        //Checks if the living entity is near a cactus or is on top of a cactus and hurts them
+        if ((blockBelow == Material.CACTUS || blockLocationX.getBlock().getType() == Material.CACTUS ||
+                blockLocationNegX.getBlock().getType() == Material.CACTUS || blockLocationZ.getBlock().getType() == Material.CACTUS ||
+                blockLocationNegZ.getBlock().getType() == Material.CACTUS) && canTakeCactusDamage()) {
+            damage(1, EntityDamageEvent.DamageCause.CONTACT);
+        }
+
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -614,4 +647,5 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     public boolean setLeashHolder(Entity holder) {
         return false;
     }
+
 }

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -131,7 +131,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             airTicks = maximumAir;
         }
 
-        takeCactusDamage();
+        takeDamageWhenHugged(Material.CACTUS);
 
         // potion effects
         List<PotionEffect> effects = new ArrayList<>(potionEffects.values());
@@ -475,17 +475,17 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         lastDamage = damage;
     }
 
-    public void takeCactusDamage() {
+    public void takeDamageWhenHugged(Material material) {
 
         BlockFace[] sides = {BlockFace.EAST, BlockFace.WEST, BlockFace.SOUTH, BlockFace.NORTH, BlockFace.UP, BlockFace.SELF,
                 BlockFace.NORTH_EAST, BlockFace.NORTH_WEST,  BlockFace.SOUTH_EAST, BlockFace.SOUTH_WEST};
 
-
         //Checks if the living entity is near a cactus or is on top of a cactus and hurts them
         for (BlockFace face : sides) {
-            if (getLocation().getBlock().getRelative(face).getType() == Material.CACTUS && canTakeDamage()) {
+            if (getLocation().getBlock().getRelative(face).getType() == material && canTakeDamage()) {
 
                 damage(1, EntityDamageEvent.DamageCause.CONTACT);
+
 
             }
 


### PR DESCRIPTION
 I added a method called canTakeCactusHurt. In the living entity class it always returns true because obviously animals aren't immune to cacti. In the GlowHumanEnity class I overrode the method so it returns true if the player is in survival mode or adventure mode. In the living entity class there is a method called takeCactusDamage. It gets the block the player is standing on as well as the blocks 1 up on each side. If they are cacti and the player canTakeCactiDamage() it hurts them.  In the livingEntity class I add an else clause so that if the no damage ticks aren't greater than zero they are reset so that the player can take damage again. Aaron helped me get set up and helped with the some of the logic.
