### PR TITLE
Parse JSON when loading sign text NBT

### DIFF
--- a/src/main/java/net/glowstone/block/entity/TESign.java
+++ b/src/main/java/net/glowstone/block/entity/TESign.java
@@ -7,7 +7,6 @@ import net.glowstone.entity.GlowPlayer;
 import net.glowstone.util.nbt.CompoundTag;
 import net.glowstone.util.TextMessage;
 import org.bukkit.Material;
-import org.json.simple.parser.ParseException;
 
 import java.util.Arrays;
 
@@ -38,12 +37,8 @@ public class TESign extends TileEntity {
             String key = "Text" + (i + 1);
             if (tag.isString(key)) {
                 String value = tag.getString(key);
-                try {
-                    TextMessage message = TextMessage.decode(value);
-                    lines[i] = message.asPlaintext();
-                } catch (ParseException e) {
-                    lines[i] = value;
-                }
+                TextMessage message = TextMessage.decode(value, value);
+                lines[i] = message.asPlaintext();
             }
         }
     }

--- a/src/main/java/net/glowstone/block/entity/TESign.java
+++ b/src/main/java/net/glowstone/block/entity/TESign.java
@@ -5,7 +5,9 @@ import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.state.GlowSign;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.util.nbt.CompoundTag;
+import net.glowstone.util.TextMessage;
 import org.bukkit.Material;
+import org.json.simple.parser.ParseException;
 
 import java.util.Arrays;
 
@@ -35,7 +37,13 @@ public class TESign extends TileEntity {
         for (int i = 0; i < lines.length; ++i) {
             String key = "Text" + (i + 1);
             if (tag.isString(key)) {
-                lines[i] = tag.getString(key);
+                String value = tag.getString(key);
+                try {
+                    TextMessage message = TextMessage.decode(value);
+                    lines[i] = message.asPlaintext();
+                } catch (ParseException e) {
+                    lines[i] = value;
+                }
             }
         }
     }

--- a/src/main/java/net/glowstone/net/GlowBufUtils.java
+++ b/src/main/java/net/glowstone/net/GlowBufUtils.java
@@ -258,7 +258,7 @@ public final class GlowBufUtils {
      * @throws IOException on read failure.
      */
     public static TextMessage readChat(ByteBuf buf) throws IOException {
-        return TextMessage.decode(ByteBufUtils.readUTF8(buf));
+        return TextMessage.decode(ByteBufUtils.readUTF8(buf), "parse error");
     }
 
     /**

--- a/src/main/java/net/glowstone/util/TextMessage.java
+++ b/src/main/java/net/glowstone/util/TextMessage.java
@@ -74,6 +74,8 @@ public final class TextMessage {
         Object o = parser.parse(json);
         if (o instanceof JSONObject) {
             return new TextMessage((JSONObject) o);
+        } else if (o == null) {
+            return new TextMessage("");
         } else {
             return new TextMessage(o.toString());
         }

--- a/src/main/java/net/glowstone/util/TextMessage.java
+++ b/src/main/java/net/glowstone/util/TextMessage.java
@@ -69,17 +69,27 @@ public final class TextMessage {
      * @param json The encoded representation.
      * @return The decoded TextMessage.
      */
-    public static TextMessage decode(String json) {
+    public static TextMessage decode(String json) throws ParseException {
         JSONParser parser = new JSONParser();
+        Object o = parser.parse(json);
+        if (o instanceof JSONObject) {
+            return new TextMessage((JSONObject) o);
+        } else {
+            return new TextMessage(o.toString());
+        }
+    }
+
+    /**
+     * Decode a chat message from its textual JSON representation if possible.
+     * @param json The encoded representation.
+     * @param fallback The string to return on parse error.
+     * @return The decoded TextMessage.
+     */
+    public static TextMessage decode(String json, String fallback) {
         try {
-            Object o = parser.parse(json);
-            if (o instanceof JSONObject) {
-                return new TextMessage((JSONObject) o);
-            } else {
-                return new TextMessage(o.toString());
-            }
+            return decode(json);
         } catch (ParseException e) {
-            return new TextMessage("parse error");
+            return new TextMessage(fallback);
         }
     }
 


### PR DESCRIPTION
Fixes #528

Still uses plaintext internally, since we don't have a robust json chat parser yet. TextMessage.asPlaintext() is rather primitive too

Saving also uses plaintext for the sake of simplicity. Vanilla handles that correctly, since it's needed when migrating from 1.7 maps.

To test this:
- Start glowstone, place some signs with text and some empty lines
- Load same world in [vanilla](https://s3.amazonaws.com/Minecraft.Download/versions/1.8/minecraft_server.1.8.jar), save (this turns sign text into json)
- Load same world in glowstone

Old behavior adds quotes around lines with content, and either `null` or `""` for lines without.

New behavior should show no differences.
