### PR TITLE
Support LilyPad proxy information (adds #569)

### DIFF
--- a/src/main/java/net/glowstone/net/ProxyData.java
+++ b/src/main/java/net/glowstone/net/ProxyData.java
@@ -6,6 +6,7 @@ import net.glowstone.util.UuidUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -17,10 +18,12 @@ import java.util.UUID;
  */
 public final class ProxyData {
 
-    private final String hostname;
-    private final InetSocketAddress address;
-    private final UUID uuid;
-    private final List<PlayerProperty> properties;
+    private String securityKey; // Lilypad security key - not used by us
+    private String hostname;
+    private InetSocketAddress address;
+    private String name;
+    private UUID uuid;
+    private List<PlayerProperty> properties;
 
     /**
      * Create a proxy data structure for a session from the given source text.
@@ -29,10 +32,52 @@ public final class ProxyData {
      * @throws Exception if an error occurs parsing the source text.
      */
     public ProxyData(GlowSession session, String sourceText) throws Exception {
+        // Attempt to parse the sourceText as JSON (LilyPad) first
+        try {
+            // This throws a ParseException if parsing failed (ie: not LilyPad)
+            JSONObject payload = (JSONObject) new JSONParser().parse(sourceText);
+
+            // LilyPad-only values
+            securityKey = (String) payload.get("s"); // Not used by us anywhere
+            name = (String) payload.get("n");
+
+            // Spoof hostname, address, and UUID
+            // LilyPad also spoofs the port, unlike Bungee
+            hostname = (String) payload.get("h");
+            uuid = UuidUtils.fromFlatString((String) payload.get("u"));
+            address = new InetSocketAddress((String) payload.get("rIp"), ((Long) payload.get("rP")).intValue());
+
+            // Extract properties, if available
+            if (payload.containsKey("p")) {
+                JSONArray props = (JSONArray) payload.get("p");
+
+                properties = new ArrayList<>(props.size());
+                for (Object obj : props) {
+                    JSONObject prop = (JSONObject) obj;
+                    String propName = (String) prop.get("n");
+                    String value = (String) prop.get("v");
+                    String signature = (String) prop.get("s");
+                    properties.add(new PlayerProperty(propName, value, signature));
+                }
+            } else {
+                properties = new ArrayList<>(0);
+            }
+
+            return; // We've processed the data, don't re-parse it as Bungee data
+        } catch (ParseException ignored) {
+            // Swallow JSON parse exception and process sourceText as Bungee data
+        }
+
+        // Likely Bungee data at this point. If not, then a friendly exception will be thrown.
+
         String[] parts = sourceText.split("\0");
         if (parts.length != 3 && parts.length != 4) {
             throw new IllegalArgumentException("parts length was " + parts.length + ", should be 3 or 4");
         }
+
+        // Set values that aren't supported or present to null
+        name = null;
+        securityKey = null;
 
         // Spoof hostname, address, and UUID
         hostname = parts[0];
@@ -57,6 +102,14 @@ public final class ProxyData {
     }
 
     /**
+     * Gets the security key sent by the proxy, if any.
+     * @return The security key, or null if not present.
+     */
+    public String getSecurityKey() {
+        return securityKey;
+    }
+
+    /**
      * Get the spoofed hostname to use instead of the actual one.
      * @return The spoofed hostname.
      */
@@ -78,6 +131,16 @@ public final class ProxyData {
      * @return The spoofed profile.
      */
     public PlayerProfile getProfile(String name) {
+        return new PlayerProfile(name, uuid, properties);
+    }
+
+    /**
+     * Get a spoofed profile to use. Returns null if the proxy did not send a
+     * username as part of the payload.
+     * @return The spoofed profile.
+     */
+    public PlayerProfile getProfile() {
+        if (name == null) return null;
         return new PlayerProfile(name, uuid, properties);
     }
 }

--- a/src/main/java/net/glowstone/net/handler/login/LoginStartHandler.java
+++ b/src/main/java/net/glowstone/net/handler/login/LoginStartHandler.java
@@ -35,7 +35,8 @@ public final class LoginStartHandler implements MessageHandler<GlowSession, Logi
                 UUID uuid = UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8));
                 session.setPlayer(new PlayerProfile(name, uuid));
             } else {
-                session.setPlayer(proxy.getProfile(name));
+                PlayerProfile profile = proxy.getProfile();
+                session.setPlayer(profile == null ? proxy.getProfile(name) : profile);
             }
         }
     }


### PR DESCRIPTION
Please refer to #569 for a technical description of the data format and why this is important.

---

This PR adds support for the proxy data sent by [LilyPad](http://www.lilypadmc.org/). This is done by attempting to parse the JSON data first. If parsing failed, then the data is likely Bungee or other (unsupported) data. If parsing passed on the other hand, then we rip it apart for our purposes. 

The Bungee parsing has only been changed to ensure that the two unsupported values are set to null. All other processing remains unchanged.

This PR also adds support for the security key LilyPad sends for it's internal use. This is not used by Glowstone at all but is included to make the lives of the LilyPad maintainers easier. By having this field exposed (to a degree) helps ensure that they don't have to keep up to date with our networking logic and rewrite the GlowProtocol used for handshakes. It will still require effort on their part to get access to this field, but at least it is much easier than having to override our networking.

It should also be noted that this PR technically allows the use of multiple proxies (ie: Bungee and LilyPad). Whether or not the independent assemblies permit that is another story, but the handling of the additional proxy data permits the use of both proxies.
