### PR TITLE
Print out bound port

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -348,9 +348,9 @@ public final class GlowServer implements Server {
     private GlowServerIcon defaultIcon;
 
     /**
-     * The server port, if set to 0 in the config.
+     * The server port.
      */
-    private int port = 0;
+    private int port;
 
     /**
      * Creates a new server.
@@ -441,9 +441,7 @@ public final class GlowServer implements Server {
         Channel channel = future.awaitUninterruptibly().channel();
         logger.info("Successfully bound to address: " + channel.localAddress());
 
-        if (getPort() == 0) {
-            port = ((InetSocketAddress) channel.localAddress()).getPort();
-        }
+        port = ((InetSocketAddress) channel.localAddress()).getPort();
 
         if (!channel.isActive()) {
             throw new RuntimeException("Failed to bind to address. Maybe it is already in use?");
@@ -1413,7 +1411,7 @@ public final class GlowServer implements Server {
 
     @Override
     public int getPort() {
-        return port == 0 ? config.getInt(ServerConfig.Key.SERVER_PORT) : port;
+        return port;
     }
 
     @Override

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -348,6 +348,11 @@ public final class GlowServer implements Server {
     private GlowServerIcon defaultIcon;
 
     /**
+     * The server port, if set to 0 in the config.
+     */
+    private int port = 0;
+
+    /**
      * Creates a new server.
      */
     public GlowServer(ServerConfig config) {
@@ -434,6 +439,12 @@ public final class GlowServer implements Server {
         logger.info("Binding to address: " + address + "...");
         ChannelFuture future = networkServer.bind(address);
         Channel channel = future.awaitUninterruptibly().channel();
+        logger.info("Successfully bound to address: " + channel.localAddress());
+
+        if (getPort() == 0) {
+            port = ((InetSocketAddress) channel.localAddress()).getPort();
+        }
+
         if (!channel.isActive()) {
             throw new RuntimeException("Failed to bind to address. Maybe it is already in use?");
         }
@@ -1402,7 +1413,7 @@ public final class GlowServer implements Server {
 
     @Override
     public int getPort() {
-        return config.getInt(ServerConfig.Key.SERVER_PORT);
+        return port == 0 ? config.getInt(ServerConfig.Key.SERVER_PORT) : port;
     }
 
     @Override


### PR DESCRIPTION
Currently, if `port` is set to `0` in the config, there's no way to determine the port that the server actually gets bound to.

This PR prints out the port that was bound t, and updates `getPort` to return the port actually bound if, if `0` was specified.
