### PR TITLE
Fixed console check on headless environments

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -42,6 +42,8 @@ import org.bukkit.scoreboard.ScoreboardManager;
 import org.bukkit.util.CachedServerIcon;
 import org.bukkit.util.permissions.DefaultPermissions;
 
+import java.awt.Desktop;
+import java.awt.GraphicsEnvironment;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.net.InetSocketAddress;
@@ -79,11 +81,11 @@ public final class GlowServer implements Server {
      */
     public static void main(String[] args) {
         try {
-            // check for console
-            /*if (System.console() == null) {
+            // check for console and desktop environment
+            if (System.console() == null && !GraphicsEnvironment.isHeadless() && Desktop.isDesktopSupported()) {
                 ConsoleMissing.display();
                 return;
-            }*/
+            }
 
             ConfigurationSerialization.registerClass(GlowOfflinePlayer.class);
             GlowPotionEffect.register();


### PR DESCRIPTION
Addresses #586 

What this does is re-enables and patches the console check to work on environments that are not headless (meaning they have a display, keyboard, or mouse) and if they support the Desktop AWT apis. 
This allows the application to run on headless servers but blocks people double clicking on windows the jar file.

This was tested on a Windows 8.1 (x64) machine running the latest Java 8 update (oracle JVM), with and without the -Djava.awt.headless=true flag.

EDIT:

This is my first PR to the Glowstone project, so forgive me If I have not followed protocol correctly.
