### PR TITLE
Travis: route builds to their new infrastructure and enable caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,28 @@
 language: java
 jdk: oraclejdk7
 
-install:
-  # Required for fetch_glowkit_pr.sh
-  - "[[ $TRAVIS_PULL_REQUEST == false ]] || sudo apt-get install jq"
+# Enable routing builds to the new container-based infrastructure
+sudo: false
 
+install:
   # Try to fetch required glowkit PRs, if any.
   - "./etc/fetch_glowkit_pr.sh $TRAVIS_PULL_REQUEST || echo 'Glowkit build failed - trying to continue anyway'"
-
-  # Fetch gradle stuff, so it doesn't appear in the script step
-  - "gradle clean"
 
 script:
   # Compile and package JAR and set build properties
   - "gradle build remap"
 
+  # Avoid including some files in the build cache
+  - "rm -rf ~/.gradle/caches/modules-2/{metadata,modules-2.lock}*"
+
 after_success:
   # Check if commit is not a pull request, if repo is official, and branch is master, generate and deploy artifacts and reports
   - "[[ $TRAVIS_PULL_REQUEST == false ]] && [[ $TRAVIS_REPO_SLUG == GlowstoneMC/Glowstone ]] && [[ $TRAVIS_BRANCH == master ]] && gradle publish"
+
+cache:
+  directories:
+    - "$HOME/.gradle"
+    - "$HOME/.m2"
 
 # Notification services
 notifications:

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ buildscript {
         maven { url "http://repo.glowstone.net/content/groups/public/" }
     }
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:1.1.2'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.0'
         classpath 'net.glowstone:remapper:1.1'
         classpath 'org.ow2.asm:asm:5.0.3'
     }


### PR DESCRIPTION
Their [new container based infrastructure](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) starts builds faster, takes half of the time to finish, and allows us to do caching of dependencies.

One random (but very nonscientific) test:
- Old: 1m54s in queue, 2m13s running, 4m07s total
- New: 0m14s in queue, 1m02s running, 1m16s total

The main downside is that that root access it not available, but it was only used for installing jq which was also [added to the build environment recently](http://docs.travis-ci.com/user/build-environment-updates/2014-12-09/).

These new servers also include gradle 2.2.1 instead of 2.0, which required an upgrade of the shadow plugin from 1.1.2 to 1.2.0. See their [changelog](https://github.com/johnrengelman/shadow/blob/master/ChangeLog.md#v120):

> Convert ShadowJar.groovy to ShadowJar.java to workaround binary incompatibility introduced by Gradle 2.2 

`~/.gradle` and `~/.m2` are cached, and a few dirs in `.gradle` are removed at the end of the script to avoid unnecessary cache updates

Also the "clean" step was removed to save a few seconds of build time, since most of the time it doesn't download libraries (not anymore)
