### PR TITLE
Add Part 1 of Passive Entities [Entities]

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowAgeable.java
+++ b/src/main/java/net/glowstone/entity/GlowAgeable.java
@@ -1,0 +1,121 @@
+package net.glowstone.entity;
+
+import com.flowpowered.networking.Message;
+import net.glowstone.entity.meta.MetadataIndex;
+import net.glowstone.entity.meta.MetadataMap;
+import net.glowstone.net.message.play.entity.EntityMetadataMessage;
+import org.bukkit.Location;
+import org.bukkit.entity.Ageable;
+import org.bukkit.entity.EntityType;
+
+import java.util.List;
+
+/**
+ * Represents a creature that ages, such as a sheep.
+ */
+public class GlowAgeable extends GlowCreature implements Ageable {
+
+    private static final int AGE_BABY = -24000;
+    private static final int AGE_ADULT = 0;
+    private static final int BREEDING_AGE = 6000;
+    protected float width, height;
+    private int age = 0;
+    private boolean ageLocked = false;
+
+    /**
+     * Creates a new ageable monster.
+     * @param location The location of the monster.
+     * @param type The type of monster.
+     */
+    public GlowAgeable(Location location, EntityType type) {
+        super(location, type);
+    }
+
+    @Override
+    public void pulse() {
+        super.pulse();
+        if (this.ageLocked) {
+            setScaleForAge(!isAdult());
+        } else {
+            int currentAge = this.age;
+            if (currentAge < AGE_ADULT) {
+                currentAge++;
+                setAge(currentAge);
+            } else if (currentAge > AGE_ADULT) {
+                currentAge--;
+                setAge(currentAge);
+            }
+        }
+    }
+
+    @Override
+    public final int getAge() {
+        return this.age;
+    }
+
+    @Override
+    public final void setAge(int age) {
+        this.age = age;
+        this.setScaleForAge(isAdult());
+    }
+
+    @Override
+    public final boolean getAgeLock() {
+        return this.ageLocked;
+    }
+
+    @Override
+    public final void setAgeLock(boolean ageLocked) {
+        this.ageLocked = ageLocked;
+    }
+
+    @Override
+    public final void setBaby() {
+        if (isAdult()) {
+            setAge(AGE_BABY);
+        }
+    }
+
+    @Override
+    public final void setAdult() {
+        if (!isAdult()) {
+            setAge(AGE_ADULT);
+        }
+    }
+
+    @Override
+    public final boolean isAdult() {
+        return this.age >= AGE_ADULT;
+    }
+
+    @Override
+    public final boolean canBreed() {
+        return this.age == AGE_ADULT;
+    }
+
+    @Override
+    public void setBreed(boolean breed) {
+        if (breed) {
+            setAge(AGE_ADULT);
+        } else if (isAdult()) {
+            setAge(BREEDING_AGE);
+        }
+    }
+
+    public void setScaleForAge(boolean isAdult) {
+        setScale(isAdult ? 1.0F : 0.5F);
+    }
+
+    @Override
+    public List<Message> createSpawnMessage() {
+        List<Message> messages = super.createSpawnMessage();
+        MetadataMap map = new MetadataMap(GlowAgeable.class);
+        map.set(MetadataIndex.AGE, this.getAge());
+        messages.add(new EntityMetadataMessage(id, map.getEntryList()));
+        return messages;
+    }
+
+    protected final void setScale(float scale) {
+        setSize(this.height * scale, this.width * scale);
+    }
+}

--- a/src/main/java/net/glowstone/entity/GlowAmbient.java
+++ b/src/main/java/net/glowstone/entity/GlowAmbient.java
@@ -1,0 +1,11 @@
+package net.glowstone.entity;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Ambient;
+
+public abstract class GlowAmbient extends GlowLivingEntity implements Ambient {
+
+    public GlowAmbient(Location location) {
+        super(location);
+    }
+}

--- a/src/main/java/net/glowstone/entity/GlowAnimal.java
+++ b/src/main/java/net/glowstone/entity/GlowAnimal.java
@@ -1,0 +1,20 @@
+package net.glowstone.entity;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Animals;
+import org.bukkit.entity.EntityType;
+
+/**
+ * Represents an Animal, such as a Cow
+ */
+public class GlowAnimal extends GlowAgeable implements Animals {
+
+    /**
+     * Creates a new ageable animal.
+     * @param location The location of the animal.
+     * @param type The type of animal.
+     */
+    public GlowAnimal(Location location, EntityType type) {
+        super(location, type);
+    }
+}

--- a/src/main/java/net/glowstone/entity/GlowCreature.java
+++ b/src/main/java/net/glowstone/entity/GlowCreature.java
@@ -13,10 +13,9 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Represents a monster such as a creeper.
- * @author Graham Edgecombe
+ * Represents a creature entity such as a pig.
  */
-public final class GlowCreature extends GlowLivingEntity implements Creature {
+public class GlowCreature extends GlowLivingEntity implements Creature {
 
     /**
      * The type of monster.

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -518,6 +518,10 @@ public abstract class GlowEntity implements Entity {
         return true;
     }
 
+    protected void setSize(float xz, float y) {
+        //todo Size stuff with bounding boxes.
+    }
+
     /**
      * Determine if this entity is intersecting a block of the specified type.
      * If the entity has a defined bounding box, that is used to check for

--- a/src/main/java/net/glowstone/entity/meta/MetadataIndex.java
+++ b/src/main/java/net/glowstone/entity/meta/MetadataIndex.java
@@ -23,7 +23,7 @@ public enum MetadataIndex {
     // allowed to override NAME_TAG from LivingEntity
     PLAYER_SKIN_FLAGS(10, BYTE, HumanEntity.class),
 
-    AGE(12, INT, Ageable.class),
+    AGE(12, BYTE, Ageable.class),
 
     HORSE_FLAGS(16, INT, Horse.class),
     HORSE_TYPE(19, BYTE, Horse.class),
@@ -102,6 +102,8 @@ public enum MetadataIndex {
     ITEM_FRAME_ROTATION(3, BYTE, ItemFrame.class),
 
     ENDER_CRYSTAL_HEALTH(8, INT, EnderCrystal.class),
+
+    RABBIT_TYPE(18, BYTE, Rabbit.class),
     ;
 
     private final int index;

--- a/src/main/java/net/glowstone/entity/passive/GlowBat.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowBat.java
@@ -1,0 +1,60 @@
+package net.glowstone.entity.passive;
+
+import com.flowpowered.networking.Message;
+import net.glowstone.entity.GlowAmbient;
+import net.glowstone.entity.meta.MetadataIndex;
+import net.glowstone.entity.meta.MetadataMap;
+import net.glowstone.net.message.play.entity.EntityHeadRotationMessage;
+import net.glowstone.net.message.play.entity.EntityMetadataMessage;
+import net.glowstone.net.message.play.entity.SpawnMobMessage;
+import net.glowstone.util.Position;
+import org.bukkit.Location;
+import org.bukkit.entity.Bat;
+import org.bukkit.entity.EntityType;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class GlowBat extends GlowAmbient implements Bat {
+
+    private boolean isAwake;
+
+    public GlowBat(Location location) {
+        super(location);
+    }
+
+    @Override
+    public List<Message> createSpawnMessage() {
+        List<Message> result = new LinkedList<>();
+
+        // spawn mob
+        int x = Position.getIntX(location);
+        int y = Position.getIntY(location);
+        int z = Position.getIntZ(location);
+        int yaw = Position.getIntYaw(location);
+        int pitch = Position.getIntPitch(location);
+        result.add(new SpawnMobMessage(id, getType().getTypeId(), x, y, z, yaw, pitch, pitch, 0, 0, 0, metadata.getEntryList()));
+
+        // head facing
+        result.add(new EntityHeadRotationMessage(id, yaw));
+        MetadataMap map = new MetadataMap(GlowBat.class);
+        map.set(MetadataIndex.BAT_HANGING, (byte) (this.isAwake ? 1 : 0));
+        result.add(new EntityMetadataMessage(id, map.getEntryList()));
+        return result;
+    }
+
+    @Override
+    public boolean isAwake() {
+        return isAwake;
+    }
+
+    @Override
+    public void setAwake(boolean isAwake) {
+        this.isAwake = isAwake;
+    }
+
+    @Override
+    public EntityType getType() {
+        return EntityType.BAT;
+    }
+}

--- a/src/main/java/net/glowstone/entity/passive/GlowChicken.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowChicken.java
@@ -1,0 +1,14 @@
+package net.glowstone.entity.passive;
+
+import net.glowstone.entity.GlowAnimal;
+import org.bukkit.Location;
+import org.bukkit.entity.Chicken;
+import org.bukkit.entity.EntityType;
+
+public class GlowChicken extends GlowAnimal implements Chicken {
+
+    public GlowChicken(Location location) {
+        super(location, EntityType.CHICKEN);
+        setSize(0.3F, 0.7F);
+    }
+}

--- a/src/main/java/net/glowstone/entity/passive/GlowHorse.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowHorse.java
@@ -1,0 +1,210 @@
+package net.glowstone.entity.passive;
+
+import com.flowpowered.networking.Message;
+import net.glowstone.entity.meta.MetadataIndex;
+import net.glowstone.entity.meta.MetadataMap;
+import net.glowstone.inventory.GlowHorseInventory;
+import net.glowstone.net.message.play.entity.EntityMetadataMessage;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.AnimalTamer;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Horse;
+import org.bukkit.inventory.HorseInventory;
+
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+public class GlowHorse extends GlowTameable implements Horse {
+
+    private Variant variant;
+    private Color horseColor;
+    private Style horseStyle;
+    private boolean hasChest;
+    private int domestication;
+    private int maxDomestication;
+    private double jumpStrength;
+    private boolean eatingHay;
+    private boolean hasReproduced;
+    private int temper;
+    private UUID ownerUUID;
+    private HorseInventory inventory = new GlowHorseInventory(this);
+
+    public GlowHorse(Location location) {
+        this(location, null);
+    }
+
+    protected GlowHorse(Location location, AnimalTamer owner) {
+        super(location, EntityType.HORSE, owner);
+        this.ownerUUID = owner.getUniqueId();
+        Random rand = new Random();
+        // Todo make this cleaner and safer to use for spawning random horses
+        this.variant = Variant.values()[rand.nextInt(4)];
+        this.horseStyle = Style.values()[rand.nextInt(3)];
+        this.horseColor = Color.values()[rand.nextInt(6)];
+    }
+
+    @Override
+    public Variant getVariant() {
+        return this.variant;
+    }
+
+    @Override
+    public void setVariant(Variant variant) {
+        this.variant = variant;
+    }
+
+    @Override
+    public Color getColor() {
+        return horseColor;
+    }
+
+    @Override
+    public void setColor(Color color) {
+        this.horseColor = color;
+    }
+
+    @Override
+    public Style getStyle() {
+        return horseStyle;
+    }
+
+    @Override
+    public void setStyle(Style style) {
+        this.horseStyle = style;
+    }
+
+    @Override
+    public boolean isCarryingChest() {
+        return hasChest;
+    }
+
+    @Override
+    public void setCarryingChest(boolean b) {
+        if (b) {
+            // TODO Manipulate the HorseInventory somehow
+        }
+        this.hasChest = b;
+    }
+
+    @Override
+    public int getDomestication() {
+        return domestication;
+    }
+
+    @Override
+    public void setDomestication(int i) {
+        this.domestication = i;
+    }
+
+    @Override
+    public int getMaxDomestication() {
+        return maxDomestication;
+    }
+
+    @Override
+    public void setMaxDomestication(int i) {
+        this.maxDomestication = i;
+    }
+
+    @Override
+    public double getJumpStrength() {
+        return jumpStrength;
+    }
+
+    @Override
+    public void setJumpStrength(double v) {
+        this.jumpStrength = v;
+    }
+
+    @Override
+    public HorseInventory getInventory() {
+        return inventory;
+    }
+
+    public void setInventory(HorseInventory inventory) {
+        this.inventory = inventory;
+    }
+
+    public boolean isEatingHay() {
+        return eatingHay;
+    }
+
+    public void setEatingHay(boolean eatingHay) {
+        this.eatingHay = eatingHay;
+    }
+
+    public boolean hasReproduced() {
+        return hasReproduced;
+    }
+
+    public void setHasReproduced(boolean hasReproduced) {
+        this.hasReproduced = hasReproduced;
+    }
+
+    public int getTemper() {
+        return temper;
+    }
+
+    public void setTemper(int temper) {
+        this.temper = temper;
+    }
+
+    public UUID getOwnerUUID() {
+        return ownerUUID;
+    }
+
+    public void setOwnerUUID(UUID ownerUUID) {
+        this.ownerUUID = ownerUUID;
+    }
+
+    @Override
+    public List<Message> createSpawnMessage() {
+        List<Message> messages = super.createSpawnMessage();
+        MetadataMap map = new MetadataMap(GlowHorse.class);
+        map.set(MetadataIndex.HORSE_TYPE, (byte) this.getVariant().ordinal());
+        map.set(MetadataIndex.HORSE_FLAGS, getHorseFlags());
+        map.set(MetadataIndex.HORSE_STYLE, getHorseStyleData());
+        map.set(MetadataIndex.HORSE_ARMOR, getHorseArmorData());
+        messages.add(new EntityMetadataMessage(id, map.getEntryList()));
+        return messages;
+    }
+
+    private int getHorseFlags() {
+        int value = 0;
+        if (isTamed()) {
+            value |= 0x02;
+        }
+        if (getInventory() != null && getInventory().getSaddle() != null) {
+            value |= 0x04;
+        }
+        if (hasChest) {
+            value |= 0x08;
+        }
+        if (hasReproduced) {
+            value |= 0x10;
+        }
+        if (isEatingHay()) {
+            value |= 0x20;
+        }
+        return value;
+    }
+
+    private int getHorseStyleData() {
+        return this.horseColor.ordinal() & 0xFF | this.horseStyle.ordinal() << 8;
+    }
+
+    private int getHorseArmorData() {
+        if (getInventory().getArmor() != null) {
+            if (getInventory().getArmor().getType() == Material.DIAMOND_BARDING) {
+                return 3;
+            } else if (getInventory().getArmor().getType() == Material.GOLD_BARDING) {
+                return 2;
+            } else if (getInventory().getArmor().getType() == Material.IRON_BARDING) {
+                return 1;
+            }
+        }
+        return 0;
+    }
+}

--- a/src/main/java/net/glowstone/entity/passive/GlowPig.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowPig.java
@@ -1,0 +1,41 @@
+package net.glowstone.entity.passive;
+
+import com.flowpowered.networking.Message;
+import net.glowstone.entity.GlowAnimal;
+import net.glowstone.entity.meta.MetadataIndex;
+import net.glowstone.entity.meta.MetadataMap;
+import net.glowstone.net.message.play.entity.EntityMetadataMessage;
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Pig;
+
+import java.util.List;
+
+public class GlowPig extends GlowAnimal implements Pig {
+
+    private boolean hasSaddle;
+
+    public GlowPig(Location location) {
+        super(location, EntityType.PIG);
+        setSize(0.9F, 0.9F);
+    }
+
+    @Override
+    public boolean hasSaddle() {
+        return hasSaddle;
+    }
+
+    @Override
+    public void setSaddle(boolean hasSaddle) {
+        this.hasSaddle = hasSaddle;
+    }
+
+    @Override
+    public List<Message> createSpawnMessage() {
+        List<Message> messages = super.createSpawnMessage();
+        MetadataMap map = new MetadataMap(GlowPig.class);
+        map.set(MetadataIndex.PIG_SADDLE, (byte) (this.hasSaddle ? 1 : 0));
+        messages.add(new EntityMetadataMessage(id, map.getEntryList()));
+        return messages;
+    }
+}

--- a/src/main/java/net/glowstone/entity/passive/GlowRabbit.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowRabbit.java
@@ -1,0 +1,54 @@
+package net.glowstone.entity.passive;
+
+import com.flowpowered.networking.Message;
+import com.google.common.collect.ImmutableBiMap;
+import net.glowstone.entity.GlowAnimal;
+import net.glowstone.entity.meta.MetadataIndex;
+import net.glowstone.entity.meta.MetadataMap;
+import net.glowstone.net.message.play.entity.EntityMetadataMessage;
+import org.apache.commons.lang.Validate;
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Rabbit;
+
+import java.util.List;
+
+public class GlowRabbit extends GlowAnimal implements Rabbit {
+
+    private static final ImmutableBiMap<RabbitType, Integer> rabbitTypeIntegerMap = ImmutableBiMap.<RabbitType, Integer>builder()
+            .put(Rabbit.RabbitType.BROWN, 0)
+            .put(Rabbit.RabbitType.WHITE, 1)
+            .put(Rabbit.RabbitType.BLACK, 2)
+            .put(Rabbit.RabbitType.BLACK_AND_WHITE, 3)
+            .put(Rabbit.RabbitType.GOLD, 4)
+            .put(Rabbit.RabbitType.SALT_PEPPER, 5)
+            .put(Rabbit.RabbitType.KILLER, 99)
+            .build();
+
+    private RabbitType rabbitType = RabbitType.BROWN;
+
+    public GlowRabbit(Location location) {
+        super(location, EntityType.RABBIT);
+        setSize(0.3F, 0.7F);
+    }
+
+    @Override
+    public RabbitType getRabbitType() {
+        return rabbitType;
+    }
+
+    @Override
+    public void setRabbitType(RabbitType type) {
+        Validate.notNull(type, "Cannot set a null rabbit type!");
+        this.rabbitType = type;
+    }
+
+    @Override
+    public List<Message> createSpawnMessage() {
+        List<Message> messages = super.createSpawnMessage();
+        MetadataMap map = new MetadataMap(GlowRabbit.class);
+        map.set(MetadataIndex.RABBIT_TYPE, rabbitTypeIntegerMap.get(this.getRabbitType()).byteValue());
+        messages.add(new EntityMetadataMessage(id, map.getEntryList()));
+        return messages;
+    }
+}

--- a/src/main/java/net/glowstone/entity/passive/GlowSheep.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowSheep.java
@@ -1,0 +1,58 @@
+package net.glowstone.entity.passive;
+
+import com.flowpowered.networking.Message;
+import net.glowstone.entity.GlowAnimal;
+import net.glowstone.entity.meta.MetadataIndex;
+import net.glowstone.entity.meta.MetadataMap;
+import net.glowstone.net.message.play.entity.EntityMetadataMessage;
+import org.bukkit.DyeColor;
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Sheep;
+
+import java.util.List;
+
+public class GlowSheep extends GlowAnimal implements Sheep {
+
+    private boolean sheared = false;
+    private DyeColor color = DyeColor.WHITE;
+
+    public GlowSheep(Location location) {
+        super(location, EntityType.SHEEP);
+        setSize(0.9F, 1.3F);
+    }
+
+    @Override
+    public boolean isSheared() {
+        return sheared;
+    }
+
+    @Override
+    public void setSheared(boolean sheared) {
+        this.sheared = sheared;
+    }
+
+    @Override
+    public DyeColor getColor() {
+        return color;
+    }
+
+    @Override
+    public void setColor(DyeColor dyeColor) {
+        this.color = dyeColor;
+    }
+
+    @Override
+    public List<Message> createSpawnMessage() {
+        List<Message> messages = super.createSpawnMessage();
+        MetadataMap map = new MetadataMap(GlowSheep.class);
+
+        map.set(MetadataIndex.SHEEP_DATA, getColorByte());
+        messages.add(new EntityMetadataMessage(id, map.getEntryList()));
+        return messages;
+    }
+
+    private byte getColorByte() {
+        return (byte) (this.getColor().getData() & (sheared ? 0x10 : 0x0F));
+    }
+}

--- a/src/main/java/net/glowstone/entity/passive/GlowTameable.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowTameable.java
@@ -1,0 +1,69 @@
+package net.glowstone.entity.passive;
+
+import net.glowstone.entity.GlowAnimal;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.AnimalTamer;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Tameable;
+
+import java.util.UUID;
+
+public abstract class GlowTameable extends GlowAnimal implements Tameable {
+
+    private AnimalTamer owner;
+    private UUID ownerUUId;
+    private boolean tamed;
+
+    public GlowTameable(Location location, EntityType type) {
+        super(location, type);
+        setSize(0.3F, 0.7F);
+    }
+
+    protected GlowTameable(Location location, EntityType type, AnimalTamer owner) {
+        super(location, type);
+        this.owner = owner;
+    }
+
+    @Override
+    public boolean isTamed() {
+        return tamed;
+    }
+
+    @Override
+    public void setTamed(boolean isTamed) {
+        this.tamed = isTamed;
+    }
+
+    @Override
+    public AnimalTamer getOwner() {
+        return owner instanceof Player ? owner : Bukkit.getPlayer(this.ownerUUId);
+    }
+
+    @Override
+    public void setOwner(AnimalTamer animalTamer) {
+        this.owner = animalTamer;
+        this.ownerUUId = animalTamer.getUniqueId();
+    }
+
+    public UUID getOwnerUUID() {
+        return this.ownerUUId;
+    }
+
+    /**
+     * Added needed method for Storage to convert from UUID to owners.
+     * The UUID's are validated through offline player checking. If a player
+     * with the specified UUID has not played on the server before, the
+     * owner is not set.
+     *
+     * @param ownerUUID
+     */
+    public void setOwnerUUID(UUID ownerUUID) {
+        OfflinePlayer player = Bukkit.getOfflinePlayer(ownerUUId);
+        if (player.hasPlayedBefore()) {
+            this.ownerUUId = ownerUUID;
+        }
+    }
+}

--- a/src/main/java/net/glowstone/inventory/GlowHorseInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowHorseInventory.java
@@ -1,0 +1,55 @@
+package net.glowstone.inventory;
+
+import org.bukkit.entity.Horse;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.HorseInventory;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * A class which represents an inventory and the items it contains.
+ */
+public class GlowHorseInventory extends GlowInventory implements HorseInventory {
+
+    private ItemStack saddle;
+    private ItemStack armor;
+
+    public GlowHorseInventory(Horse owner) {
+        this(owner, owner.isCarryingChest() ? 16 : 2);
+    }
+
+    public GlowHorseInventory(Horse owner, int size) {
+        this(owner, size, "EntityHorse");
+    }
+
+    public GlowHorseInventory(Horse owner, int size, String title) {
+        super(owner, InventoryType.CHEST, size, title); //TODO fix this.
+    }
+
+    @Override
+    public ItemStack getSaddle() {
+        return saddle != null ? saddle.clone() : null;
+    }
+
+    @Override
+    public ItemStack getArmor() {
+        return armor != null ? armor.clone() : null;
+    }
+
+    @Override
+    public void setSaddle(ItemStack itemStack) {
+        if (itemStack != null) {
+            this.saddle = new ItemStack(itemStack);
+        } else {
+            this.armor = null;
+        }
+    }
+
+    @Override
+    public void setArmor(ItemStack itemStack) {
+        if (itemStack != null) {
+            this.armor = new ItemStack(itemStack);
+        } else {
+            this.armor = null;
+        }
+    }
+}

--- a/src/main/java/net/glowstone/io/entity/AgeableStore.java
+++ b/src/main/java/net/glowstone/io/entity/AgeableStore.java
@@ -1,0 +1,47 @@
+package net.glowstone.io.entity;
+
+import net.glowstone.entity.GlowAgeable;
+import net.glowstone.util.nbt.CompoundTag;
+import org.bukkit.Location;
+
+import java.lang.reflect.Constructor;
+
+class AgeableStore<T extends GlowAgeable> extends CreatureStore<T> {
+
+    private final Constructor<T> constructor;
+
+    public AgeableStore(Class<T> clazz, String id) {
+        super(clazz, id);
+        Constructor<T> ctor = null;
+        try {
+            ctor = clazz.getConstructor(Location.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        this.constructor = ctor;
+    }
+
+    @Override
+    public T createEntity(Location location, CompoundTag compound) {
+        try {
+            return constructor.newInstance(location);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new UnsupportedOperationException("Not implemented yet.");
+        }
+    }
+
+    public void load(T entity, CompoundTag compound) {
+        super.load(entity, compound);
+        entity.setAge(compound.getInt("Age"));
+        if (compound.containsKey("AgeLocked")) {
+            entity.setAgeLock(compound.getBool("AgeLocked"));
+        }
+    }
+
+    public void save(T entity, CompoundTag tag) {
+        super.save(entity, tag);
+        tag.putInt("Age", entity.getAge());
+        tag.putBool("AgeLocked", entity.getAgeLock());
+    }
+}

--- a/src/main/java/net/glowstone/io/entity/BatStore.java
+++ b/src/main/java/net/glowstone/io/entity/BatStore.java
@@ -1,0 +1,27 @@
+package net.glowstone.io.entity;
+
+import net.glowstone.entity.passive.GlowBat;
+import net.glowstone.util.nbt.CompoundTag;
+import org.bukkit.Location;
+
+class BatStore extends LivingEntityStore<GlowBat> {
+
+    public BatStore() {
+        super(GlowBat.class, "Bat");
+    }
+
+    @Override
+    public GlowBat createEntity(Location location, CompoundTag compound) {
+        return new GlowBat(location);
+    }
+
+    public void load(GlowBat entity, CompoundTag compound) {
+        super.load(entity, compound);
+        entity.setAwake(compound.getByte("BatFlags") == 1);
+    }
+
+    public void save(GlowBat entity, CompoundTag tag) {
+        super.save(entity, tag);
+        tag.putByte("BatFlags", entity.isAwake() ? 1 : 0);
+    }
+}

--- a/src/main/java/net/glowstone/io/entity/CreatureStore.java
+++ b/src/main/java/net/glowstone/io/entity/CreatureStore.java
@@ -1,0 +1,19 @@
+package net.glowstone.io.entity;
+
+import net.glowstone.entity.GlowCreature;
+import net.glowstone.util.nbt.CompoundTag;
+
+abstract class CreatureStore<T extends GlowCreature> extends LivingEntityStore<T> {
+
+    public CreatureStore(Class<T> clazz, String id) {
+        super(clazz, id);
+    }
+
+    public void load(T entity, CompoundTag compound) {
+        super.load(entity, compound);
+    }
+
+    public void save(T entity, CompoundTag tag) {
+        super.save(entity, tag);
+    }
+}

--- a/src/main/java/net/glowstone/io/entity/EntityStorage.java
+++ b/src/main/java/net/glowstone/io/entity/EntityStorage.java
@@ -2,6 +2,7 @@ package net.glowstone.io.entity;
 
 import net.glowstone.GlowWorld;
 import net.glowstone.entity.GlowEntity;
+import net.glowstone.entity.passive.GlowChicken;
 import net.glowstone.io.nbt.NbtSerialization;
 import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.Location;
@@ -36,6 +37,15 @@ public final class EntityStorage {
      */
     static {
         bind(new PlayerStore());
+
+        // LivingEntities - Passive Entities
+        bind(new BatStore());
+        bind(new AgeableStore<>(GlowChicken.class, "Chicken"));
+        bind(new HorseStore());
+        bind(new PigStore());
+        bind(new RabbitStore());
+        bind(new SheepStore());
+
         bind(new ItemStore());
         bind(new TNTPrimedStorage());
     }

--- a/src/main/java/net/glowstone/io/entity/EntityStore.java
+++ b/src/main/java/net/glowstone/io/entity/EntityStore.java
@@ -13,8 +13,8 @@ import java.util.UUID;
  * @param <T> The type of entity being stored.
  */
 abstract class EntityStore<T extends GlowEntity> {
+    protected final Class<T> clazz;
     private final String id;
-    private final Class<T> clazz;
 
     public EntityStore(Class<T> clazz, String id) {
         this.id = id;

--- a/src/main/java/net/glowstone/io/entity/HorseStore.java
+++ b/src/main/java/net/glowstone/io/entity/HorseStore.java
@@ -1,0 +1,102 @@
+package net.glowstone.io.entity;
+
+import net.glowstone.entity.passive.GlowHorse;
+import net.glowstone.io.nbt.NbtSerialization;
+import net.glowstone.util.nbt.CompoundTag;
+import net.glowstone.util.nbt.TagType;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Horse;
+import org.bukkit.entity.Horse.Style;
+import org.bukkit.entity.Horse.Variant;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.UUID;
+
+class HorseStore extends AgeableStore<GlowHorse> {
+
+    public static final String ITEMS_KEY = "Items";
+    private static final String EATING_HAYSTACK_KEY = "EatingHaystack";
+    private static final String BRED_KEY = "Bred";
+    private static final String CHESTED_HORSE_KEY = "ChestedHorse";
+    private static final String HAS_REPRODUCED_KEY = "HasReproduced";
+    private static final String TYPE_KEY = "Type";
+    private static final String VARIANT_KEY = "Variant";
+    private static final String TEMPER_Key = "Temper";
+    private static final String TAME_KEY = "Tame";
+    private static final String OWNER_UUID_KEY = "OwnerUUID";
+    private static final String ARMOR_ITEM_KEY = "ArmorItem";
+    private static final String SADDLE_ITEM_KEY = "SaddleItem";
+    private static final String SADDLE_KEY = "Saddle";
+
+    public HorseStore() {
+        super(GlowHorse.class, "EntityHorse");
+    }
+
+    @Override
+    public GlowHorse createEntity(Location location, CompoundTag compound) {
+        return new GlowHorse(location);
+    }
+
+    public void load(GlowHorse entity, CompoundTag compound) {
+        super.load(entity, compound);
+        entity.setEatingHay(compound.getBool(EATING_HAYSTACK_KEY));
+        entity.setCarryingChest(compound.getBool(CHESTED_HORSE_KEY));
+        entity.setHasReproduced(compound.getBool(HAS_REPRODUCED_KEY));
+        entity.setStyle(Style.values()[compound.getInt(VARIANT_KEY) >>> 8]);
+        entity.setColor(Horse.Color.values()[compound.getInt(VARIANT_KEY) & 0xFF]);
+        entity.setVariant(Variant.values()[compound.getInt(TYPE_KEY)]);
+        entity.setTemper(compound.getInt(TEMPER_Key));
+        entity.setTamed(compound.getBool(TAME_KEY));
+        if (compound.containsKey(OWNER_UUID_KEY)) {
+            String uuidKey = compound.getString(OWNER_UUID_KEY);
+            if (uuidKey.isEmpty()) {
+                entity.setOwnerUUID(null);
+            } else {
+                entity.setOwnerUUID(UUID.fromString(uuidKey));
+            }
+        }
+        if (compound.containsKey(ARMOR_ITEM_KEY)) {
+            entity.getInventory().setArmor(NbtSerialization.readItem(compound.getCompound(ARMOR_ITEM_KEY)));
+        }
+        if (compound.containsKey(SADDLE_ITEM_KEY)) {
+            entity.getInventory().setSaddle(NbtSerialization.readItem(compound.getCompound(SADDLE_ITEM_KEY)));
+        } else if (compound.containsKey(SADDLE_KEY)) {
+            if (compound.getBool(SADDLE_KEY)) {
+                entity.getInventory().setSaddle(new ItemStack(Material.SADDLE));
+            }
+        }
+        if (entity.isCarryingChest()) {
+//            NbtSerialization.readInventory(compound.getCompoundList(ITEMS_KEY), 0, 10); TODO actually implement this properly
+        }
+
+    }
+
+    public void save(GlowHorse entity, CompoundTag tag) {
+        super.save(entity, tag);
+        tag.putBool(EATING_HAYSTACK_KEY, entity.isEatingHay());
+        tag.putBool(CHESTED_HORSE_KEY, entity.isCarryingChest());
+        tag.putBool(HAS_REPRODUCED_KEY, entity.hasReproduced());
+        tag.putBool(BRED_KEY, true);
+        tag.putInt(VARIANT_KEY, entity.getStyle().ordinal() << 8 | entity.getColor().ordinal() & 0xFF);
+        tag.putInt(TYPE_KEY, entity.getVariant().ordinal());
+        tag.putBool(SADDLE_KEY, entity.getInventory().getSaddle() != null);
+        tag.putInt(TEMPER_Key, entity.getTemper());
+        tag.putBool(TAME_KEY, entity.isTamed());
+        if (entity.getInventory().getArmor() != null) {
+            tag.putCompound(ARMOR_ITEM_KEY, NbtSerialization.writeItem(entity.getInventory().getArmor(), -1));
+        }
+        if (entity.getInventory().getSaddle() != null) {
+            tag.putCompound(SADDLE_ITEM_KEY, NbtSerialization.writeItem(entity.getInventory().getSaddle(), -1));
+        }
+        if (entity.isCarryingChest()) {
+            tag.putList(ITEMS_KEY, TagType.COMPOUND,
+                    NbtSerialization.writeInventory(entity.getInventory().getContents(), entity.getInventory().getContents().length));
+        }
+        if (entity.getOwnerUUID() == null) {
+            tag.putString(OWNER_UUID_KEY, "");
+        } else {
+            tag.putString(OWNER_UUID_KEY, entity.getOwnerUUID().toString());
+        }
+    }
+}

--- a/src/main/java/net/glowstone/io/entity/LivingEntityStore.java
+++ b/src/main/java/net/glowstone/io/entity/LivingEntityStore.java
@@ -85,24 +85,26 @@ abstract class LivingEntityStore<T extends GlowLivingEntity> extends EntityStore
         }
 
         EntityEquipment equip = entity.getEquipment();
-        if (compound.isList("Equipment", TagType.COMPOUND)) {
-            List<CompoundTag> list = compound.getCompoundList("Equipment");
-            if (list.size() == 5) {
-                equip.setItemInHand(NbtSerialization.readItem(list.get(0)));
-                equip.setBoots(NbtSerialization.readItem(list.get(1)));
-                equip.setLeggings(NbtSerialization.readItem(list.get(2)));
-                equip.setChestplate(NbtSerialization.readItem(list.get(3)));
-                equip.setHelmet(NbtSerialization.readItem(list.get(4)));
+        if (equip != null) {
+            if (compound.isList("Equipment", TagType.COMPOUND)) {
+                List<CompoundTag> list = compound.getCompoundList("Equipment");
+                if (list.size() == 5) {
+                    equip.setItemInHand(NbtSerialization.readItem(list.get(0)));
+                    equip.setBoots(NbtSerialization.readItem(list.get(1)));
+                    equip.setLeggings(NbtSerialization.readItem(list.get(2)));
+                    equip.setChestplate(NbtSerialization.readItem(list.get(3)));
+                    equip.setHelmet(NbtSerialization.readItem(list.get(4)));
+                }
             }
-        }
-        if (compound.isList("DropChances", TagType.FLOAT)) {
-            List<Float> list = compound.getList("DropChances", TagType.FLOAT);
-            if (list.size() == 5) {
-                equip.setItemInHandDropChance(list.get(0));
-                equip.setBootsDropChance(list.get(1));
-                equip.setLeggingsDropChance(list.get(2));
-                equip.setChestplateDropChance(list.get(3));
-                equip.setHelmetDropChance(list.get(4));
+            if (compound.isList("DropChances", TagType.FLOAT)) {
+                List<Float> list = compound.getList("DropChances", TagType.FLOAT);
+                if (list.size() == 5) {
+                    equip.setItemInHandDropChance(list.get(0));
+                    equip.setBootsDropChance(list.get(1));
+                    equip.setLeggingsDropChance(list.get(2));
+                    equip.setChestplateDropChance(list.get(3));
+                    equip.setHelmetDropChance(list.get(4));
+                }
             }
         }
         if (compound.isByte("CanPickUpLoot")) {
@@ -137,20 +139,22 @@ abstract class LivingEntityStore<T extends GlowLivingEntity> extends EntityStore
         tag.putCompoundList("ActiveEffects", effects);
 
         EntityEquipment equip = entity.getEquipment();
-        tag.putCompoundList("Equipment", Arrays.asList(
-                NbtSerialization.writeItem(equip.getItemInHand(), -1),
-                NbtSerialization.writeItem(equip.getBoots(), -1),
-                NbtSerialization.writeItem(equip.getLeggings(), -1),
-                NbtSerialization.writeItem(equip.getChestplate(), -1),
-                NbtSerialization.writeItem(equip.getHelmet(), -1)
-        ));
-        tag.putList("DropChances", TagType.FLOAT, Arrays.asList(
-                equip.getItemInHandDropChance(),
-                equip.getBootsDropChance(),
-                equip.getLeggingsDropChance(),
-                equip.getChestplateDropChance(),
-                equip.getHelmetDropChance()
-        ));
+        if (equip != null) {
+            tag.putCompoundList("Equipment", Arrays.asList(
+                    NbtSerialization.writeItem(equip.getItemInHand(), -1),
+                    NbtSerialization.writeItem(equip.getBoots(), -1),
+                    NbtSerialization.writeItem(equip.getLeggings(), -1),
+                    NbtSerialization.writeItem(equip.getChestplate(), -1),
+                    NbtSerialization.writeItem(equip.getHelmet(), -1)
+            ));
+            tag.putList("DropChances", TagType.FLOAT, Arrays.asList(
+                    equip.getItemInHandDropChance(),
+                    equip.getBootsDropChance(),
+                    equip.getLeggingsDropChance(),
+                    equip.getChestplateDropChance(),
+                    equip.getHelmetDropChance()
+            ));
+        }
         tag.putBool("CanPickUpLoot", entity.getCanPickupItems());
     }
 }

--- a/src/main/java/net/glowstone/io/entity/PigStore.java
+++ b/src/main/java/net/glowstone/io/entity/PigStore.java
@@ -1,0 +1,27 @@
+package net.glowstone.io.entity;
+
+import net.glowstone.entity.passive.GlowPig;
+import net.glowstone.util.nbt.CompoundTag;
+import org.bukkit.Location;
+
+class PigStore extends AgeableStore<GlowPig> {
+
+    public PigStore() {
+        super(GlowPig.class, "Pig");
+    }
+
+    @Override
+    public GlowPig createEntity(Location location, CompoundTag compound) {
+        return new GlowPig(location);
+    }
+
+    public void load(GlowPig entity, CompoundTag compound) {
+        super.load(entity, compound);
+        entity.setSaddle(compound.getBool("Saddle"));
+    }
+
+    public void save(GlowPig entity, CompoundTag tag) {
+        super.save(entity, tag);
+        tag.putBool("Saddle", entity.hasSaddle());
+    }
+}

--- a/src/main/java/net/glowstone/io/entity/RabbitStore.java
+++ b/src/main/java/net/glowstone/io/entity/RabbitStore.java
@@ -1,0 +1,64 @@
+package net.glowstone.io.entity;
+
+import com.google.common.collect.ImmutableMap;
+import net.glowstone.entity.passive.GlowRabbit;
+import net.glowstone.util.nbt.CompoundTag;
+import org.bukkit.Location;
+import org.bukkit.entity.Rabbit;
+
+import java.util.Map;
+
+class RabbitStore extends AgeableStore<GlowRabbit> {
+
+    private final Map<Integer, Rabbit.RabbitType> rabbitTypeMap = ImmutableMap.<Integer, Rabbit.RabbitType>builder()
+            .put(0, Rabbit.RabbitType.BROWN)
+            .put(1, Rabbit.RabbitType.WHITE)
+            .put(2, Rabbit.RabbitType.BLACK)
+            .put(3, Rabbit.RabbitType.BLACK_AND_WHITE)
+            .put(4, Rabbit.RabbitType.GOLD)
+            .put(5, Rabbit.RabbitType.SALT_PEPPER)
+            .put(99, Rabbit.RabbitType.KILLER)
+            .build();
+    private final Map<Rabbit.RabbitType, Integer> rabbitTypeIntegerMap = ImmutableMap.<Rabbit.RabbitType, Integer>builder()
+            .put(Rabbit.RabbitType.BROWN, 0)
+            .put(Rabbit.RabbitType.WHITE, 1)
+            .put(Rabbit.RabbitType.BLACK, 2)
+            .put(Rabbit.RabbitType.BLACK_AND_WHITE, 3)
+            .put(Rabbit.RabbitType.GOLD, 4)
+            .put(Rabbit.RabbitType.SALT_PEPPER, 5)
+            .put(Rabbit.RabbitType.KILLER, 99)
+            .build();
+
+    public RabbitStore() {
+        super(GlowRabbit.class, "Rabbit");
+    }
+
+    @Override
+    public GlowRabbit createEntity(Location location, CompoundTag compound) {
+        return new GlowRabbit(location);
+    }
+
+    @Override
+    public void load(GlowRabbit entity, CompoundTag compound) {
+        super.load(entity, compound);
+        Rabbit.RabbitType rabbitType;
+        int rabbitId = compound.getInt("RabbitType");
+        if (rabbitTypeMap.containsKey(rabbitId)) {
+            rabbitType = rabbitTypeMap.get(rabbitId);
+        } else {
+            rabbitType = Rabbit.RabbitType.BROWN;
+        }
+        entity.setRabbitType(rabbitType);
+        // TODO "MoreCarrotTicks" -> int
+    }
+
+    @Override
+    public void save(GlowRabbit entity, CompoundTag tag) {
+        super.save(entity, tag);
+        Rabbit.RabbitType rabbitType = entity.getRabbitType();
+        if (rabbitType == null) {
+            rabbitType = Rabbit.RabbitType.BROWN;
+        }
+        tag.putInt("RabbitType", rabbitTypeIntegerMap.get(rabbitType));
+    }
+}

--- a/src/main/java/net/glowstone/io/entity/SheepStore.java
+++ b/src/main/java/net/glowstone/io/entity/SheepStore.java
@@ -1,0 +1,33 @@
+package net.glowstone.io.entity;
+
+import net.glowstone.entity.passive.GlowSheep;
+import net.glowstone.util.nbt.CompoundTag;
+import org.bukkit.DyeColor;
+import org.bukkit.Location;
+
+class SheepStore extends AgeableStore<GlowSheep> {
+
+    public static final String SHEARED_KEY = "Sheared";
+    public static final String COLOR_KEY = "Color";
+
+    public SheepStore() {
+        super(GlowSheep.class, "Sheep");
+    }
+
+    @Override
+    public GlowSheep createEntity(Location location, CompoundTag compound) {
+        return new GlowSheep(location);
+    }
+
+    public void load(GlowSheep entity, CompoundTag compound) {
+        super.load(entity, compound);
+        entity.setColor(DyeColor.values()[compound.getByte(COLOR_KEY)]);
+        entity.setSheared(compound.getBool(SHEARED_KEY));
+    }
+
+    public void save(GlowSheep entity, CompoundTag tag) {
+        super.save(entity, tag);
+        tag.putByte(COLOR_KEY, entity.getColor().ordinal());
+        tag.putBool(SHEARED_KEY, entity.isSheared());
+    }
+}

--- a/src/main/java/net/glowstone/io/entity/TameableStore.java
+++ b/src/main/java/net/glowstone/io/entity/TameableStore.java
@@ -1,0 +1,46 @@
+package net.glowstone.io.entity;
+
+import net.glowstone.entity.passive.GlowTameable;
+import net.glowstone.util.nbt.CompoundTag;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+
+import java.util.UUID;
+
+public abstract class TameableStore<T extends GlowTameable> extends AgeableStore<T> {
+
+    public TameableStore(Class<T> clazz, String id) {
+        super(clazz, id);
+    }
+
+    @Override
+    public void load(T entity, CompoundTag compound) {
+        // TODO make this better.
+        super.load(entity, compound);
+        if (compound.containsKey("OwnerUUID") && !compound.getString("OwnerUUID").isEmpty()) {
+            entity.setOwnerUUID(UUID.fromString(compound.getString("OwnerUUID")));
+            if (Bukkit.getPlayer(entity.getOwnerUUID()) != null) {
+                entity.setOwner(Bukkit.getPlayer(entity.getOwnerUUID()));
+            }
+        } else if (compound.containsKey("Owner") && !compound.getString("Owner").isEmpty()) {
+            String playerName = compound.getString("Owner");
+            OfflinePlayer player = Bukkit.getOfflinePlayer(playerName);
+            if (player.hasPlayedBefore()) {
+                entity.setOwnerUUID(player.getUniqueId());
+                if (Bukkit.getPlayer(entity.getOwnerUUID()) != null) {
+                    entity.setOwner(Bukkit.getPlayer(entity.getOwnerUUID()));
+                }
+            }
+        }
+    }
+
+    @Override
+    public void save(T entity, CompoundTag tag) {
+        super.save(entity, tag);
+        if (entity.getOwner() == null) {
+            tag.putString("OwnerUUID", "");
+        } else {
+            tag.putString("OwnerUUID", entity.getOwner().getUniqueId().toString());
+        }
+    }
+}

--- a/src/test/java/net/glowstone/net/ProtocolTestUtils.java
+++ b/src/test/java/net/glowstone/net/ProtocolTestUtils.java
@@ -32,7 +32,7 @@ public final class ProtocolTestUtils {
 
     public static List<MetadataMap.Entry> getMetadataEntry() {
         List<MetadataMap.Entry> list = new ArrayList<>();
-        list.add(new MetadataMap.Entry(MetadataIndex.AGE, 1));
+        list.add(new MetadataMap.Entry(MetadataIndex.AGE, (byte) 1));
         return list;
     }
 


### PR DESCRIPTION
This is a smaller PR that bases the entirety of the entities feature for Glowstone.

The entities implemented in this PR are:
- [x] GlowBat
- [x] GlowChicken
- [x] GlowHorse
- [x] GlowPig
- [x] GlowRabbit
- [x] GlowSheep

The following are implementations of various interfaces required by the above entities (and some other entities to be added after this PR is merged):
- [x] GlowTameable
- [x] GlowAgeable
- [x] GlowAmbient
- [x] GlowAnimal

Included are the storages for the implemented entities with the following:
- [x] BatStore
- [x] AgeableStore
- [x] CreatureStore
- [x] TameableStore
- [x] HorseStore
- [x] PigStore
- [x] RabbitStore
- [x] SheepStore

This PR depends on GlowstoneMC/Glowkit#31
