### PR TITLE
Allow using Glowstones Io utils without requiring a world

### DIFF
--- a/src/main/java/net/glowstone/GlowChunkSnapshot.java
+++ b/src/main/java/net/glowstone/GlowChunkSnapshot.java
@@ -24,8 +24,13 @@ public class GlowChunkSnapshot implements ChunkSnapshot {
     public GlowChunkSnapshot(int x, int z, World world, ChunkSection[] sections, byte[] height, byte[] biomes, boolean svTemp) {
         this.x = x;
         this.z = z;
-        this.world = world.getName();
-        this.time = world.getFullTime();
+        if (world == null) {
+            this.world = null;
+            this.time = 0;
+        } else {
+            this.world = world.getName();
+            this.time = world.getFullTime();
+        }
 
         int numSections = sections != null ? sections.length : 0;
         this.sections = new ChunkSection[numSections];
@@ -63,6 +68,7 @@ public class GlowChunkSnapshot implements ChunkSnapshot {
 
     /**
      * Get the ChunkSection array backing this snapshot. In general, it should not be modified.
+     *
      * @return The array of ChunkSections.
      */
     public ChunkSection[] getRawSections() {

--- a/src/main/java/net/glowstone/block/GlowBlock.java
+++ b/src/main/java/net/glowstone/block/GlowBlock.java
@@ -1,5 +1,8 @@
 package net.glowstone.block;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
 import net.glowstone.GlowChunk;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.blocktype.BlockType;
@@ -17,10 +20,6 @@ import org.bukkit.metadata.MetadataStore;
 import org.bukkit.metadata.MetadataStoreBase;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Random;
 
 /**
  * Represents a single block in a world.
@@ -211,9 +210,12 @@ public final class GlowBlock implements Block {
             applyPhysics(oldTypeId, type, oldData, data);
         }
 
-        BlockChangeMessage bcmsg = new BlockChangeMessage(x, y, z, type, data);
-        for (GlowPlayer p : getWorld().getRawPlayers()) {
-            p.sendBlockChange(bcmsg);
+        GlowWorld world = getWorld();
+        if (world != null) {
+            BlockChangeMessage bcmsg = new BlockChangeMessage(x, y, z, type, data);
+            for (GlowPlayer p : world.getRawPlayers()) {
+                p.sendBlockChange(bcmsg);
+            }
         }
 
         return true;
@@ -250,9 +252,12 @@ public final class GlowBlock implements Block {
         if (applyPhysics) {
             applyPhysics(getType(), getTypeId(), oldData, data);
         }
-        BlockChangeMessage bcmsg = new BlockChangeMessage(x, y, z, getTypeId(), data);
-        for (GlowPlayer p : getWorld().getRawPlayers()) {
-            p.sendBlockChange(bcmsg);
+        GlowWorld world = getWorld();
+        if (world != null) {
+            BlockChangeMessage bcmsg = new BlockChangeMessage(x, y, z, getTypeId(), data);
+            for (GlowPlayer p : getWorld().getRawPlayers()) {
+                p.sendBlockChange(bcmsg);
+            }
         }
     }
 


### PR DESCRIPTION
Essentially, Glowstone's IO utils can be used to load a world without creating a server. The one problem that arises, is that the GlowBlock class assumes there is a server/world. This cancels sending update packets to players if the block is not in a server/world.
