### PR TITLE
Adding cauldron

### DIFF
--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -185,7 +185,7 @@ public final class ItemTable {
         reg(Material.STATIONARY_WATER, new BlockWater());
         reg(Material.LAVA, new BlockLava());
         reg(Material.STATIONARY_LAVA, new BlockLava());
-        reg(Material.CAULDRON, new BlockDirectDrops(Material.CAULDRON_ITEM, ToolType.PICKAXE));
+        reg(Material.CAULDRON, new BlockCauldron());
         reg(Material.STANDING_BANNER, new BlockBanner());
         reg(Material.WALL_BANNER, new BlockBanner());
         reg(Material.SPONGE, new BlockSponge());

--- a/src/main/java/net/glowstone/block/blocktype/BlockCauldron.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCauldron.java
@@ -5,15 +5,18 @@ import net.glowstone.entity.GlowPlayer;
 import net.glowstone.inventory.GlowItemFactory;
 import net.glowstone.inventory.MaterialMatcher;
 import net.glowstone.inventory.ToolType;
+import org.bukkit.BannerPattern;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BannerMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.util.Vector;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public class BlockCauldron extends BlockNeedsTool {
@@ -74,8 +77,32 @@ public class BlockCauldron extends BlockNeedsTool {
     }
 
     private boolean bleachBanner(GlowPlayer player, GlowBlock block) {
-        //TODO: bleaching banners with cauldron
-        return false;
+        if (player.getGameMode() == GameMode.CREATIVE)
+            return false;
+
+        if (block.getData() > 0) {
+            ItemStack inHand = player.getItemInHand();
+            BannerMeta meta = (BannerMeta) inHand.getItemMeta();
+            BannerPattern pattern = meta.getPattern();
+            List<BannerPattern.BannerLayer> layers = pattern.getLayers();
+            if (layers == null || layers.isEmpty()) {
+                return false;
+            }
+
+            BannerPattern.Builder builder = BannerPattern.builder();
+            for (int i = 0; i < layers.size() - 1; i++) {
+                BannerPattern.BannerLayer layer = layers.get(i);
+                builder.layer(layer.getTexture(), layer.getColor());
+            }
+
+            meta.setPattern(builder.build());
+            inHand.setItemMeta(meta);
+
+            block.setData((byte) (block.getData() - 1));
+            return true;
+        } else {
+            return false;
+        }
     }
 
     private boolean bleachLeatherArmor(GlowPlayer player, GlowBlock block) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockCauldron.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCauldron.java
@@ -1,0 +1,103 @@
+package net.glowstone.block.blocktype;
+
+import net.glowstone.block.GlowBlock;
+import net.glowstone.entity.GlowPlayer;
+import net.glowstone.inventory.GlowItemFactory;
+import net.glowstone.inventory.MaterialMatcher;
+import net.glowstone.inventory.ToolType;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.util.Vector;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+public class BlockCauldron extends BlockNeedsTool {
+    private static final Collection<ItemStack> DROP = Arrays.asList(new ItemStack(Material.CAULDRON_ITEM));
+
+    @Override
+    public boolean blockInteract(GlowPlayer player, GlowBlock block, BlockFace face, Vector clickedLoc) {
+        if (player.getItemInHand() == null) {
+            return super.blockInteract(player, block, face, clickedLoc);
+        }
+
+        switch (player.getItemInHand().getType()) {
+            case WATER_BUCKET:
+                fillCauldron(player, block);
+                return true;
+
+            case GLASS_BOTTLE:
+                fillBottle(player, block);
+                return true;
+
+            case LEATHER_BOOTS:
+            case LEATHER_LEGGINGS:
+            case LEATHER_CHESTPLATE:
+            case LEATHER_HELMET:
+                return bleachLeatherArmor(player, block);
+
+            case BANNER:
+                return bleachBanner(player, block);
+
+            default:
+                return super.blockInteract(player, block, face, clickedLoc);
+        }
+    }
+
+    private void fillCauldron(GlowPlayer player, GlowBlock block) {
+        if (block.getData() < 3) {
+            if (player.getGameMode() != GameMode.CREATIVE) {
+                player.getItemInHand().setType(Material.BUCKET);
+            }
+
+            block.setData((byte) 3);
+        }
+    }
+
+    private void fillBottle(GlowPlayer player, GlowBlock block) {
+        if (block.getData() > 0) {
+            block.setData((byte) (block.getData() - 1));
+
+            if (player.getGameMode() != GameMode.CREATIVE) {
+                Map<Integer, ItemStack> drops = player.getInventory().addItem(new ItemStack(Material.POTION));
+                if (!drops.isEmpty()) {
+                    player.getWorld().dropItemNaturally(player.getLocation(), new ItemStack(Material.POTION));
+                }
+
+                player.getItemInHand().setAmount(player.getItemInHand().getAmount() - 1);
+            }
+        }
+    }
+
+    private boolean bleachBanner(GlowPlayer player, GlowBlock block) {
+        //TODO: bleaching banners with cauldron
+        return false;
+    }
+
+    private boolean bleachLeatherArmor(GlowPlayer player, GlowBlock block) {
+        if (block.getData() > 0) {
+            ItemStack inHand = player.getItemInHand();
+            LeatherArmorMeta im = (LeatherArmorMeta) inHand.getItemMeta();
+            im.setColor(GlowItemFactory.instance().getDefaultLeatherColor());
+            inHand.setItemMeta(im);
+            block.setData((byte) (block.getData() - 1));
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public Collection<ItemStack> getMinedDrops(GlowBlock block, ItemStack tool) {
+        return DROP;
+    }
+
+    @Override
+    protected MaterialMatcher getNeededMiningTool(GlowBlock block) {
+        return ToolType.PICKAXE;
+    }
+}


### PR DESCRIPTION
This PR adds BlockCauldron:
- filling the cauldron with WATER_BUCKET
- filling water bottles with the cauldron
- bleaching LeatherArmor and Banner

Everything is tested with a inventory generated in vanilla minecraft (colored armor and banner with pattern).
