### PR TITLE
Fix new worlds starting off with thundering rain

### DIFF
--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -170,7 +170,7 @@ public final class GlowWorld implements World {
     /**
      * Whether it is currently raining/snowing on this world.
      */
-    private boolean currentlyRaining = false;
+    private boolean currentlyRaining = true;
 
     /**
      * How many ticks until the rain/snow status is expected to change.
@@ -180,7 +180,7 @@ public final class GlowWorld implements World {
     /**
      * Whether it is currently thundering on this world.
      */
-    private boolean currentlyThundering = false;
+    private boolean currentlyThundering = true;
 
     /**
      * How many ticks until the thundering status is expected to change.

--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -170,7 +170,7 @@ public final class GlowWorld implements World {
     /**
      * Whether it is currently raining/snowing on this world.
      */
-    private boolean currentlyRaining = true;
+    private boolean currentlyRaining = false;
 
     /**
      * How many ticks until the rain/snow status is expected to change.
@@ -180,7 +180,7 @@ public final class GlowWorld implements World {
     /**
      * Whether it is currently thundering on this world.
      */
-    private boolean currentlyThundering = true;
+    private boolean currentlyThundering = false;
 
     /**
      * How many ticks until the thundering status is expected to change.

--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -281,6 +281,9 @@ public final class GlowWorld implements World {
             this.uid = UUID.randomUUID();
         }
 
+        this.scheduleStorm();
+        this.scheduleThundering();
+
         // begin loading spawn area
         spawnChunkLock = newChunkLock("spawn");
         server.addWorld(this);
@@ -1121,6 +1124,15 @@ public final class GlowWorld implements World {
         return currentlyRaining;
     }
 
+    private void scheduleStorm() {
+        // Numbers borrowed from CraftBukkit.
+        if (currentlyRaining) {
+            setWeatherDuration(random.nextInt(12000) + 12000);
+        } else {
+            setWeatherDuration(random.nextInt(168000) + 12000);
+        }
+    }
+
     @Override
     public void setStorm(boolean hasStorm) {
         // call event
@@ -1133,12 +1145,7 @@ public final class GlowWorld implements World {
         boolean previouslyRaining = currentlyRaining;
         currentlyRaining = hasStorm;
 
-        // Numbers borrowed from CraftBukkit.
-        if (currentlyRaining) {
-            setWeatherDuration(random.nextInt(12000) + 12000);
-        } else {
-            setWeatherDuration(random.nextInt(168000) + 12000);
-        }
+        scheduleStorm();
 
         // update players
         if (previouslyRaining != currentlyRaining) {
@@ -1163,6 +1170,15 @@ public final class GlowWorld implements World {
         return currentlyThundering;
     }
 
+    private void scheduleThundering() {
+        // Numbers borrowed from CraftBukkit.
+        if (currentlyThundering) {
+            setThunderDuration(random.nextInt(12000) + 3600);
+        } else {
+            setThunderDuration(random.nextInt(168000) + 12000);
+        }
+    }
+
     @Override
     public void setThundering(boolean thundering) {
         // call event
@@ -1174,12 +1190,7 @@ public final class GlowWorld implements World {
         // change weather
         currentlyThundering = thundering;
 
-        // Numbers borrowed from CraftBukkit.
-        if (currentlyThundering) {
-            setThunderDuration(random.nextInt(12000) + 3600);
-        } else {
-            setThunderDuration(random.nextInt(168000) + 12000);
-        }
+        scheduleThundering();
     }
 
     @Override


### PR DESCRIPTION
Currently all new worlds begin with both rain and thundering enabled. This PR changes this so new worlds begin with clear weather, no rain and no thundering.

Although currentlyRaining and currentlyThundering were initialized to false, since rainingTicks and thunderingTicks are initialized to 0, and are decremented to <= 0 on each tick, a weather transition occurs immediately, from false to true. Initializing the currentlyX variables to true flips this transition from false to true.

A more comprehensive fix might be a good idea, but would be more complex. I kept this PR as simple as possible to fix the observed behavior (new worlds annoyingly begin with stormy rain). May also want to investigate avoiding the initial weather transition (set rainingTicks and thunderingTicks to >0? but this value is random, calculated in setStorm() and setThundering(). Call setStorm(false) and setThundering(false) on newly-created worlds, to properly initialize the weather state? But this will still send the WeatherChangeEvents, may or may not be a problem), though I'd consider that improvement out of the scope of this PR; thoughts?
