### PR TITLE
Fixes #622

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -378,6 +378,17 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         getServer().setPlayerOnline(this, false);
         super.remove();
     }
+    
+    public void remove(boolean asyncSave) {
+        knownChunks.clear();
+        chunkLock.clear();
+        saveData(asyncSave);
+        getInventory().removeViewer(this);
+        getInventory().getCraftingInventory().removeViewer(this);
+        permissions.clearPermissions();
+        getServer().setPlayerOnline(this, false);
+        super.remove();
+    }
 
     @Override
     public boolean shouldSave() {
@@ -1267,6 +1278,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public void kickPlayer(String message) {
+        remove(false);
         session.disconnect(message == null ? "" : message);
     }
 


### PR DESCRIPTION
This is to fix issue #622. 
Simply has the player data being saved when the player is kicked.

The `saveData` method is called as a non-asynchronous save in order to save the player data before the server shuts down. With an asynchronous save during shutdown, the server will kill the save thread, thus not saving any player data.
